### PR TITLE
Fix compilation of integration tests

### DIFF
--- a/near-plugins/src/test_utils.rs
+++ b/near-plugins/src/test_utils.rs
@@ -17,7 +17,7 @@ pub(crate) fn get_context() -> VMContext {
         account_locked_balance: 0,
         storage_usage: 10_000,
         attached_deposit: 0,
-        prepaid_gas: Gas(10u64.pow(18)),
+        prepaid_gas: Gas(1_000_000 * Gas::ONE_TERA.0),
         random_seed: [0; 32],
         output_data_receivers: vec![],
         epoch_height: 19,

--- a/near-plugins/src/test_utils.rs
+++ b/near-plugins/src/test_utils.rs
@@ -1,4 +1,4 @@
-use near_sdk::VMContext;
+use near_sdk::{Gas, VMContext};
 use std::convert::TryInto;
 
 #[allow(dead_code)]
@@ -6,7 +6,9 @@ pub(crate) fn get_context() -> VMContext {
     VMContext {
         current_account_id: "alice.test".to_string().try_into().unwrap(),
         signer_account_id: "bob.test".to_string().try_into().unwrap(),
-        signer_account_pk: vec![0, 1, 2],
+        signer_account_pk: "ed25519:6E8sCci9badyRkXb3JoRpBj5p8C6Tw41ELDZoiihKEtp"
+            .parse()
+            .unwrap(),
         predecessor_account_id: "alice.test".to_string().try_into().unwrap(),
         input: vec![],
         block_index: 0,
@@ -15,8 +17,8 @@ pub(crate) fn get_context() -> VMContext {
         account_locked_balance: 0,
         storage_usage: 10_000,
         attached_deposit: 0,
-        prepaid_gas: 10u64.pow(18),
-        random_seed: vec![0, 1, 2],
+        prepaid_gas: Gas(10u64.pow(18)),
+        random_seed: [0; 32],
         output_data_receivers: vec![],
         epoch_height: 19,
         view_config: None,


### PR DESCRIPTION
Without these changes integration tests in `near-plugins/tests` don't compile (in my setup).