### PR TITLE
Add functions to manage Acl (super-)admins

### DIFF
--- a/near-plugins/src/access_controllable.rs
+++ b/near-plugins/src/access_controllable.rs
@@ -19,8 +19,54 @@ pub trait AccessControllable {
     /// Returns the storage prefix for collections related to access control.
     fn acl_storage_prefix() -> &'static [u8];
 
+    /// Makes `account_id` an admin provided that the predecessor has sufficient
+    /// permissions, i.e. is an admin as defined by [`acl_is_admin`].
+    ///
+    /// In case of sufficient permissions, the returned `Some(bool)` indicates
+    /// whether `account_id` is a new admin for `role`. Without permissions,
+    /// `None` is returned and internal state is not modified.
+    ///
+    /// Note that any role may have multiple (or zero) admins.
+    fn acl_add_admin(&mut self, role: String, account_id: AccountId) -> Option<bool>;
+
+    /// Makes `account_id` an admin for role, __without__ checking any
+    /// permissions. Returns whether `account_id` is a new admin for `role`.
+    ///
+    /// Note that any role may have multiple (or zero) admins.
+    ///
+    /// This method is `#[private]` in the implementation provided by this
+    /// crate.
+    fn acl_add_admin_unchecked(&mut self, role: String, account_id: AccountId) -> bool;
+
+    /// Returns whether `account_id` is an admin for `role`. Super-admins are
+    /// admins for _every_ role.
+    fn acl_is_admin(&self, role: String, account_id: AccountId) -> bool;
+
+    /// Revoke admin permissions for `role` from `account_id` provided that the
+    /// predecessor has sufficient permissions, i.e. is an admin as defined by
+    /// [`acl_is_admin`].
+    ///
+    /// In case of sufficient permissions, the returned `Some(bool)` indicates
+    /// whether `account_id` was an admin for `role`. Without permissions,
+    /// `None` is returned and internal state is not modified.
+    fn acl_revoke_admin(&mut self, role: String, account_id: AccountId) -> Option<bool>;
+
+    /// Revokes admin permissions for `role` from the predecessor. Returns
+    /// whether the predecessor was an admin for `role`.
+    fn acl_renounce_admin(&mut self, role: String) -> bool;
+
+    /// Revokes admin permissions from `account_id` __without__ checking any
+    /// permissions. Returns whether `account_id` was an admin for `role`.
+    ///
+    /// This method is `#[private]` in the implementation provided by this
+    /// crate.
+    fn acl_revoke_admin_unchecked(&mut self, role: String, account_id: AccountId) -> bool;
+
     /// Grants `role` to `account_id` __without__ checking any permissions.
     /// Returns whether `role` was newly granted to `account_id`.
+    ///
+    /// This method is `#[private]` in the implementation provided by this
+    /// crate.
     fn acl_grant_role_unchecked(&mut self, role: String, account_id: AccountId) -> bool;
 
     /// Returns whether `account_id` has been granted `role`.
@@ -37,6 +83,73 @@ pub mod events {
 
     const STANDARD: &str = "AccessControllable";
     const VERSION: &str = "1.0.0";
+
+    /// Event emitted when an accout is made super-admin.
+    #[derive(Serialize, Clone)]
+    #[serde(crate = "near_sdk::serde")]
+    pub struct SuperAdminAdded {
+        /// Account that was added as super-admin.
+        pub account: AccountId,
+        /// Account that added the super-admin.
+        pub by: AccountId,
+    }
+
+    impl AsEvent<SuperAdminAdded> for SuperAdminAdded {
+        fn metadata(&self) -> EventMetadata<SuperAdminAdded> {
+            EventMetadata {
+                standard: STANDARD.to_string(),
+                version: VERSION.to_string(),
+                event: "super_admin_added".to_string(),
+                data: Some(self.clone()),
+            }
+        }
+    }
+
+    /// Event emitted when an account is made admin.
+    #[derive(Serialize, Clone)]
+    #[serde(crate = "near_sdk::serde")]
+    pub struct AdminAdded {
+        /// The Role for which an admin was added.
+        pub role: String,
+        /// Account that was added as admin.
+        pub account: AccountId,
+        /// Account that added the admin.
+        pub by: AccountId,
+    }
+
+    impl AsEvent<AdminAdded> for AdminAdded {
+        fn metadata(&self) -> EventMetadata<AdminAdded> {
+            EventMetadata {
+                standard: STANDARD.to_string(),
+                version: VERSION.to_string(),
+                event: "admin_added".to_string(),
+                data: Some(self.clone()),
+            }
+        }
+    }
+
+    /// Event emitted when admin permissions are revoked.
+    #[derive(Serialize, Clone)]
+    #[serde(crate = "near_sdk::serde")]
+    pub struct AdminRevoked {
+        /// The Role for which an admin was revoked.
+        pub role: String,
+        /// Account from whom permissions where revoked.
+        pub account: AccountId,
+        /// Account that revoked the admin.
+        pub by: AccountId,
+    }
+
+    impl AsEvent<AdminRevoked> for AdminRevoked {
+        fn metadata(&self) -> EventMetadata<AdminRevoked> {
+            EventMetadata {
+                standard: STANDARD.to_string(),
+                version: VERSION.to_string(),
+                event: "admin_revoked".to_string(),
+                data: Some(self.clone()),
+            }
+        }
+    }
 
     /// Event emitted when a role is granted to an account.
     #[derive(Serialize, Clone)]

--- a/near-plugins/tests/access_controllable.rs
+++ b/near-plugins/tests/access_controllable.rs
@@ -1,13 +1,17 @@
 mod common;
 
 use common::access_controllable_contract::{AccessControllableContract, Caller};
-use common::utils::{assert_insufficient_acl_permissions, assert_private_method_failure};
+use common::utils::{
+    assert_insufficient_acl_permissions, assert_private_method_failure, assert_success_with,
+};
 use near_sdk::serde_json::json;
 use workspaces::network::Sandbox;
 use workspaces::result::ExecutionFinalResult;
 use workspaces::{Account, Contract, Worker};
 
 const PROJECT_PATH: &str = "./tests/contracts/access_controllable";
+
+// TODO verify return values (e.g. of acl_add_admin)
 
 /// Bundles resources required in tests.
 struct Setup {
@@ -38,6 +42,18 @@ impl Setup {
         for &role in roles {
             self.contract
                 .acl_grant_role_unchecked(Caller::Contract, role, account.id())
+                .await?
+                .into_result()?;
+        }
+        Ok(account)
+    }
+
+    /// Returns a new account that is admin for `roles`.
+    async fn new_account_as_admin(&self, roles: &[&str]) -> anyhow::Result<Account> {
+        let account = self.worker.dev_create_account().await?;
+        for &role in roles {
+            self.contract
+                .acl_add_admin_unchecked(Caller::Contract, role, account.id())
                 .await?
                 .into_result()?;
         }
@@ -143,13 +159,251 @@ async fn test_set_and_get_status() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn test_acl_is_admin() -> anyhow::Result<()> {
+    let Setup {
+        contract, account, ..
+    } = Setup::new().await?;
+    let role = "LevelA";
+
+    // TODO super-admin related cases
+
+    let is_admin = contract
+        .acl_is_admin(account.clone().into(), role, account.id())
+        .await?;
+    assert_eq!(is_admin, false);
+
+    contract
+        .acl_add_admin_unchecked(Caller::Contract, role, account.id())
+        .await?
+        .into_result()?;
+
+    let is_admin = contract
+        .acl_is_admin(account.clone().into(), role, account.id())
+        .await?;
+    assert_eq!(is_admin, true);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_acl_add_admin() -> anyhow::Result<()> {
+    let Setup {
+        worker,
+        contract,
+        account,
+        ..
+    } = Setup::new().await?;
+    let role = "LevelA";
+
+    let acc_adding_admin = account;
+    let acc_to_be_admin = worker.dev_create_account().await?;
+
+    contract
+        .assert_acl_is_admin(false, role, acc_to_be_admin.id())
+        .await;
+
+    // An account which isn't admin can't add admins.
+    let added = contract
+        .acl_add_admin(acc_adding_admin.clone().into(), role, acc_to_be_admin.id())
+        .await?;
+    assert_eq!(added, None);
+
+    // Admin can add others as admin.
+    contract
+        .acl_add_admin_unchecked(Caller::Contract, role, acc_adding_admin.id())
+        .await?
+        .into_result()?;
+    let added = contract
+        .acl_add_admin(acc_adding_admin.clone().into(), role, acc_to_be_admin.id())
+        .await?;
+    assert_eq!(added, Some(true));
+    contract
+        .assert_acl_is_admin(true, role, acc_to_be_admin.id())
+        .await;
+
+    // Adding an account that is already admin.
+    let added = contract
+        .acl_add_admin(acc_adding_admin.clone().into(), role, acc_to_be_admin.id())
+        .await?;
+    assert_eq!(added, Some(false));
+
+    // TODO test super admin may add admin for a roles he's not admin for
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_acl_add_admin_unchecked() -> anyhow::Result<()> {
+    let Setup {
+        contract, account, ..
+    } = Setup::new().await?;
+    let role = "LevelA";
+
+    contract
+        .assert_acl_is_admin(false, role, account.id())
+        .await;
+    contract
+        .acl_add_admin_unchecked(Caller::Contract, role, account.id())
+        .await?
+        .into_result()?;
+    contract.assert_acl_is_admin(true, role, account.id()).await;
+
+    // Adding as admin again doesn't lead to failures.
+    contract
+        .acl_add_admin_unchecked(Caller::Contract, role, account.id())
+        .await?
+        .into_result()?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_acl_revoke_admin() -> anyhow::Result<()> {
+    let setup = Setup::new().await?;
+    let role = "LevelB";
+    let admin = setup.new_account_as_admin(&[role]).await?;
+
+    setup
+        .contract
+        .assert_acl_is_admin(true, role, admin.id())
+        .await;
+
+    // Revoke is a no-op if revoker is not an admin for the role.
+    let revoker = setup.new_account_as_admin(&[]).await?;
+    let res = setup
+        .contract
+        .acl_revoke_admin(revoker.into(), role, admin.id())
+        .await?;
+    assert_eq!(res, None);
+    let revoker = setup.new_account_as_admin(&["LevelA"]).await?;
+    let res = setup
+        .contract
+        .acl_revoke_admin(revoker.into(), role, admin.id())
+        .await?;
+    assert_eq!(res, None);
+    setup
+        .contract
+        .assert_acl_is_admin(true, role, admin.id())
+        .await;
+
+    // Revoke succeeds if the revoker is an admin for the role.
+    let revoker = setup.new_account_as_admin(&[role]).await?;
+    let res = setup
+        .contract
+        .acl_revoke_admin(revoker.into(), role, admin.id())
+        .await?;
+    assert_eq!(res, Some(true));
+    setup
+        .contract
+        .assert_acl_is_admin(false, role, admin.id())
+        .await;
+
+    // Revoking a role for which the account isn't admin returns `Some(false)`.
+    let revoker = setup.new_account_as_admin(&[role]).await?;
+    let account = setup.worker.dev_create_account().await?;
+    let res = setup
+        .contract
+        .acl_revoke_admin(revoker.into(), role, account.id())
+        .await?;
+    assert_eq!(res, Some(false));
+
+    // TODO super-admin may revoke any role.
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_acl_renounce_admin() -> anyhow::Result<()> {
+    let setup = Setup::new().await?;
+    let role = "LevelC";
+
+    // An account which is isn't admin calls `acl_renounce_admin`.
+    let res = setup
+        .contract
+        .acl_renounce_admin(setup.account.clone().into(), role)
+        .await?;
+    assert_eq!(res, false);
+
+    // An admin calls `acl_renounce_admin`.
+    let admin = setup.new_account_as_admin(&[role]).await?;
+    setup
+        .contract
+        .assert_acl_is_admin(true, role, admin.id())
+        .await;
+    let res = setup
+        .contract
+        .acl_renounce_admin(admin.clone().into(), role)
+        .await?;
+    assert_eq!(res, true);
+    setup
+        .contract
+        .assert_acl_is_admin(false, role, admin.id())
+        .await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_acl_revoke_admin_unchecked() -> anyhow::Result<()> {
+    let setup = Setup::new().await?;
+    let account = setup.new_account_as_admin(&["LevelA", "LevelC"]).await?;
+
+    setup
+        .contract
+        .assert_acl_is_admin(true, "LevelA", account.id())
+        .await;
+    setup
+        .contract
+        .assert_acl_is_admin(true, "LevelC", account.id())
+        .await;
+
+    // Revoke admin permissions for one of the roles.
+    let res = setup
+        .contract
+        .acl_revoke_admin_unchecked(Caller::Contract, "LevelA", account.id())
+        .await?;
+    assert_success_with(res, true);
+    setup
+        .contract
+        .assert_acl_is_admin(false, "LevelA", account.id())
+        .await;
+    setup
+        .contract
+        .assert_acl_is_admin(true, "LevelC", account.id())
+        .await;
+
+    // Revoke admin permissions for the other role too.
+    let res = setup
+        .contract
+        .acl_revoke_admin_unchecked(Caller::Contract, "LevelC", account.id())
+        .await?;
+    assert_success_with(res, true);
+    setup
+        .contract
+        .assert_acl_is_admin(false, "LevelA", account.id())
+        .await;
+    setup
+        .contract
+        .assert_acl_is_admin(false, "LevelC", account.id())
+        .await;
+
+    // Revoking behaves as expected if the permission is not present.
+    let res = setup
+        .contract
+        .acl_revoke_admin_unchecked(Caller::Contract, "LevelC", account.id())
+        .await?;
+    assert_success_with(res, false);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_acl_has_role() -> anyhow::Result<()> {
     let Setup {
         contract, account, ..
     } = Setup::new().await?;
     let role = "LevelA";
 
-    // Anyone may call `acl_has_role`.
     let has_role = contract
         .acl_has_role(account.clone().into(), role, account.id())
         .await?;
@@ -165,18 +419,6 @@ async fn test_acl_has_role() -> anyhow::Result<()> {
         .await?;
     assert_eq!(has_role, true);
 
-    Ok(())
-}
-
-#[tokio::test]
-async fn test_acl_grant_role_unchecked_is_private() -> anyhow::Result<()> {
-    let Setup {
-        contract, account, ..
-    } = Setup::new().await?;
-    let res = contract
-        .acl_grant_role_unchecked(account.clone().into(), "LevelA", account.id())
-        .await?;
-    assert_private_method_failure(res, "acl_grant_role_unchecked");
     Ok(())
 }
 
@@ -250,5 +492,41 @@ async fn test_attribute_access_control_any() -> anyhow::Result<()> {
     // TODO once admin fns are implemented, add tests for cases mentioned in
     // https://github.com/aurora-is-near/near-plugins/pull/5#discussion_r973784721
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_acl_add_admin_unchecked_is_private() -> anyhow::Result<()> {
+    let Setup {
+        contract, account, ..
+    } = Setup::new().await?;
+    let res = contract
+        .acl_add_admin_unchecked(account.clone().into(), "LevelA", account.id())
+        .await?;
+    assert_private_method_failure(res, "acl_add_admin_unchecked");
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_acl_grant_role_unchecked_is_private() -> anyhow::Result<()> {
+    let Setup {
+        contract, account, ..
+    } = Setup::new().await?;
+    let res = contract
+        .acl_grant_role_unchecked(account.clone().into(), "LevelA", account.id())
+        .await?;
+    assert_private_method_failure(res, "acl_grant_role_unchecked");
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_acl_revoke_admin_unchecked_is_private() -> anyhow::Result<()> {
+    let Setup {
+        contract, account, ..
+    } = Setup::new().await?;
+    let res = contract
+        .acl_revoke_admin_unchecked(account.clone().into(), "LevelA", account.id())
+        .await?;
+    assert_private_method_failure(res, "acl_revoke_admin_unchecked");
     Ok(())
 }

--- a/near-plugins/tests/access_controllable.rs
+++ b/near-plugins/tests/access_controllable.rs
@@ -411,17 +411,17 @@ async fn test_acl_add_admin_unchecked() -> anyhow::Result<()> {
     contract
         .assert_acl_is_admin(false, role, account.id())
         .await;
-    contract
+    let res = contract
         .acl_add_admin_unchecked(Caller::Contract, role, account.id())
-        .await?
-        .into_result()?;
+        .await?;
+    assert_success_with(res, true);
     contract.assert_acl_is_admin(true, role, account.id()).await;
 
-    // Adding as admin again doesn't lead to failures.
-    contract
+    // Adding as admin again behaves as expected.
+    let res = contract
         .acl_add_admin_unchecked(Caller::Contract, role, account.id())
-        .await?
-        .into_result()?;
+        .await?;
+    assert_success_with(res, false);
 
     Ok(())
 }
@@ -599,17 +599,17 @@ async fn test_acl_grant_role_unchecked() -> anyhow::Result<()> {
     contract
         .assert_acl_has_role(false, role, account.id())
         .await;
-    contract
+    let res = contract
         .acl_grant_role_unchecked(Caller::Contract, role, account.id())
-        .await?
-        .into_result()?;
+        .await?;
+    assert_success_with(res, true);
     contract.assert_acl_has_role(true, role, account.id()).await;
 
-    // Granting a role again doesn't lead to failures.
-    contract
+    // Granting a role again behaves as expected.
+    let res = contract
         .acl_grant_role_unchecked(Caller::Contract, role, account.id())
-        .await?
-        .into_result()?;
+        .await?;
+    assert_success_with(res, false);
 
     Ok(())
 }

--- a/near-plugins/tests/common/access_controllable_contract.rs
+++ b/near-plugins/tests/common/access_controllable_contract.rs
@@ -39,6 +39,60 @@ impl AccessControllableContract {
         }
     }
 
+    pub async fn acl_is_super_admin(
+        &self,
+        caller: Caller,
+        account_id: &AccountId,
+    ) -> anyhow::Result<bool> {
+        let res = self
+            .account(caller)
+            .call(self.contract.id(), "acl_is_super_admin")
+            .args_json(json!({
+                "account_id": account_id,
+            }))
+            .view()
+            .await?;
+        Ok(res.json::<bool>()?)
+    }
+
+    pub async fn assert_acl_is_super_admin(&self, expected: bool, account_id: &AccountId) {
+        let is_super_admin = self
+            .acl_is_super_admin(Caller::Contract, account_id)
+            .await
+            .unwrap();
+        assert_eq!(is_super_admin, expected);
+    }
+
+    pub async fn acl_add_super_admin_unchecked(
+        &self,
+        caller: Caller,
+        account_id: &AccountId,
+    ) -> workspaces::Result<ExecutionFinalResult> {
+        self.account(caller)
+            .call(self.contract.id(), "acl_add_super_admin_unchecked")
+            .args_json(json!({
+                "account_id": account_id,
+            }))
+            .max_gas()
+            .transact()
+            .await
+    }
+
+    pub async fn acl_revoke_super_admin_unchecked(
+        &self,
+        caller: Caller,
+        account_id: &AccountId,
+    ) -> workspaces::Result<ExecutionFinalResult> {
+        self.account(caller)
+            .call(self.contract.id(), "acl_revoke_super_admin_unchecked")
+            .args_json(json!({
+                "account_id": account_id,
+            }))
+            .max_gas()
+            .transact()
+            .await
+    }
+
     pub async fn acl_is_admin(
         &self,
         caller: Caller,

--- a/near-plugins/tests/common/access_controllable_contract.rs
+++ b/near-plugins/tests/common/access_controllable_contract.rs
@@ -39,6 +39,123 @@ impl AccessControllableContract {
         }
     }
 
+    pub async fn acl_is_admin(
+        &self,
+        caller: Caller,
+        role: &str,
+        account_id: &AccountId,
+    ) -> anyhow::Result<bool> {
+        let res = self
+            .account(caller)
+            .call(self.contract.id(), "acl_is_admin")
+            .args_json(json!({
+                "role": role,
+                "account_id": account_id,
+            }))
+            .view()
+            .await?;
+        Ok(res.json::<bool>()?)
+    }
+
+    pub async fn assert_acl_is_admin(&self, expected: bool, role: &str, account_id: &AccountId) {
+        let is_admin = self
+            .acl_is_admin(Caller::Contract, role, account_id)
+            .await
+            .unwrap();
+        assert_eq!(is_admin, expected);
+    }
+
+    pub async fn acl_add_admin(
+        &self,
+        caller: Caller,
+        role: &str,
+        account_id: &AccountId,
+    ) -> anyhow::Result<Option<bool>> {
+        let res = self
+            .account(caller)
+            .call(self.contract.id(), "acl_add_admin")
+            .args_json(json!({
+                "role": role,
+                "account_id": account_id,
+            }))
+            .max_gas()
+            .transact()
+            .await?
+            .into_result()?
+            .json::<Option<bool>>()?;
+        Ok(res)
+    }
+
+    pub async fn acl_add_admin_unchecked(
+        &self,
+        caller: Caller,
+        role: &str,
+        account_id: &AccountId,
+    ) -> workspaces::Result<ExecutionFinalResult> {
+        self.account(caller)
+            .call(self.contract.id(), "acl_add_admin_unchecked")
+            .args_json(json!({
+                "role": role,
+                "account_id": account_id,
+            }))
+            .max_gas()
+            .transact()
+            .await
+    }
+
+    pub async fn acl_revoke_admin(
+        &self,
+        caller: Caller,
+        role: &str,
+        account_id: &AccountId,
+    ) -> anyhow::Result<Option<bool>> {
+        let res = self
+            .account(caller)
+            .call(self.contract.id(), "acl_revoke_admin")
+            .args_json(json!({
+                "role": role,
+                "account_id": account_id,
+            }))
+            .max_gas()
+            .transact()
+            .await?
+            .into_result()?
+            .json::<Option<bool>>()?;
+        Ok(res)
+    }
+
+    pub async fn acl_renounce_admin(&self, caller: Caller, role: &str) -> anyhow::Result<bool> {
+        let res = self
+            .account(caller)
+            .call(self.contract.id(), "acl_renounce_admin")
+            .args_json(json!({
+                "role": role,
+            }))
+            .max_gas()
+            .transact()
+            .await?
+            .into_result()?
+            .json::<bool>()?;
+        Ok(res)
+    }
+
+    pub async fn acl_revoke_admin_unchecked(
+        &self,
+        caller: Caller,
+        role: &str,
+        account_id: &AccountId,
+    ) -> workspaces::Result<ExecutionFinalResult> {
+        self.account(caller)
+            .call(self.contract.id(), "acl_revoke_admin_unchecked")
+            .args_json(json!({
+                "role": role,
+                "account_id": account_id,
+            }))
+            .max_gas()
+            .transact()
+            .await
+    }
+
     pub async fn acl_has_role(
         &self,
         caller: Caller,

--- a/near-plugins/tests/common/utils.rs
+++ b/near-plugins/tests/common/utils.rs
@@ -1,4 +1,20 @@
+use near_sdk::serde::de::DeserializeOwned;
+use std::cmp::PartialEq;
+use std::fmt::Debug;
 use workspaces::result::ExecutionFinalResult;
+
+/// Asserts execution was successful and returned the `expected` value.
+pub fn assert_success_with<T>(res: ExecutionFinalResult, expected: T)
+where
+    T: DeserializeOwned + PartialEq + Debug,
+{
+    let actual = res
+        .into_result()
+        .expect("Transaction should have succeeded")
+        .json::<T>()
+        .expect("Return value should be deserializable");
+    assert_eq!(actual, expected);
+}
 
 /// Asserts transaction failure due to `method` being `#[private]`.
 pub fn assert_private_method_failure(res: ExecutionFinalResult, method: &str) {


### PR DESCRIPTION
This PR builds on top of #5 and adds Acl functions related to (super-)admin permissions. A super-admin may act as admin for every role, [these tests](https://github.com/mooori/near-plugins/blob/9bbc751f2bb9ff265aa8f37472b282814463b8fb/near-plugins/tests/access_controllable.rs#L251-L332) provide an overview of super-admin permissions.

## Overview
- Trait methods are added to `AccessControllable`.
- These new methods are implement for a struct with `#[access_controllable]`.
- New methods are tested in `near-plugins/tests/access_controllable.rs`

```
# Command to execute the tests:
cargo test --test access_controllable

# This makes `workspaces` write more than 1G to /tmp (on my machine).
# Depending on the size of your /tmp, a cleanup might be required afterwards.
du --summarize --total --human-readable /tmp/sandbox-*
rm -r /tmp/sandbox-*
```

## Notes on super-admin
Currently only `acl_{add, revoke}_super_admin_unchecked` are added, i.e. only the contract itself may add and revoke super-admins. Potential further additions could be:

```
Allow super-admin to add/revoke other accounts as super-admin.
- acl_add_super_admin(account_id)
- acl_revoke_super_admin(account_id)

Allow a super-admin to renounce their super-admin permission.
- acl_renounce_super_admin()

All of the above are basically just wrappers for
acl_{add, revoke}_super_admin_unchecked which verify the permission of the
caller.
```

## Next up
A follow-up PR to add some missing functions related to roles:

```
acl_grant_role
acl_revoke_role[_unchecked]
acl_renounce_role
```

