### PR TITLE
Add functions to manage Acl roles

### DIFF
--- a/near-plugins-derive/src/access_controllable.rs
+++ b/near-plugins-derive/src/access_controllable.rs
@@ -433,11 +433,6 @@ pub fn access_controllable(attrs: TokenStream, item: TokenStream) -> TokenStream
                 self.#acl_field.is_super_admin(&account_id)
             }
 
-            #[private]
-            fn acl_init_super_admin(&mut self, account_id: ::near_sdk::AccountId) -> bool {
-                self.#acl_field.init_super_admin(&account_id)
-            }
-
             fn acl_add_admin(&mut self, role: String, account_id: ::near_sdk::AccountId) -> Option<bool> {
                 let role = <#role_type>::try_from(role.as_str()).expect(#ERR_PARSE_ROLE);
                 self.#acl_field.add_admin(role, &account_id)
@@ -458,10 +453,14 @@ pub fn access_controllable(attrs: TokenStream, item: TokenStream) -> TokenStream
                 self.#acl_field.renounce_admin(role)
             }
 
-            #[private]
-            fn acl_revoke_admin_unchecked(&mut self, role: String, account_id: ::near_sdk::AccountId) -> bool {
+            fn acl_revoke_role(&mut self, role: String, account_id: ::near_sdk::AccountId) -> Option<bool> {
                 let role = <#role_type>::try_from(role.as_str()).expect(#ERR_PARSE_ROLE);
-                self.#acl_field.revoke_admin_unchecked(role, &account_id)
+                self.#acl_field.revoke_role(role, &account_id)
+            }
+
+            fn acl_renounce_role(&mut self, role: String) -> bool {
+                let role = <#role_type>::try_from(role.as_str()).expect(#ERR_PARSE_ROLE);
+                self.#acl_field.renounce_role(role)
             }
 
             fn acl_grant_role(&mut self, role: String, account_id: ::near_sdk::AccountId) -> Option<bool> {
@@ -469,11 +468,6 @@ pub fn access_controllable(attrs: TokenStream, item: TokenStream) -> TokenStream
                 self.#acl_field.grant_role(role, &account_id)
             }
 
-            #[private]
-            fn acl_grant_role_unchecked(&mut self, role: String, account_id: ::near_sdk::AccountId) -> bool {
-                let role = <#role_type>::try_from(role.as_str()).expect(#ERR_PARSE_ROLE);
-                self.#acl_field.grant_role_unchecked(role, &account_id)
-            }
 
             fn acl_has_role(&self, role: String, account_id: ::near_sdk::AccountId) -> bool {
                 let role = <#role_type>::try_from(role.as_str()).expect(#ERR_PARSE_ROLE);

--- a/near-plugins-derive/src/access_controllable.rs
+++ b/near-plugins-derive/src/access_controllable.rs
@@ -477,13 +477,7 @@ pub fn access_controllable(attrs: TokenStream, item: TokenStream) -> TokenStream
 
             fn acl_has_role(&self, role: String, account_id: ::near_sdk::AccountId) -> bool {
                 let role = <#role_type>::try_from(role.as_str()).expect(#ERR_PARSE_ROLE);
-                self.#acl_field.renounce_role(role)
-            }
-
-            #[private]
-            fn acl_revoke_role_unchecked(&mut self, role: String, account_id: ::near_sdk::AccountId) -> bool {
-                let role = <#role_type>::try_from(role.as_str()).expect(#ERR_PARSE_ROLE);
-                self.#acl_field.revoke_role_unchecked(role, &account_id)
+                self.#acl_field.has_role(role, &account_id)
             }
 
             fn acl_has_any_role(&self, roles: Vec<String>, account_id: ::near_sdk::AccountId) -> bool {

--- a/near-plugins/src/access_controllable.rs
+++ b/near-plugins/src/access_controllable.rs
@@ -19,18 +19,6 @@ pub trait AccessControllable {
     /// Returns the storage prefix for collections related to access control.
     fn acl_storage_prefix() -> &'static [u8];
 
-    /// Adds `account_id` as super-admin __without__ checking any permissions in
-    /// case there are no super-admins. This function can be used to add a
-    /// super-admin during contract initialization. Moreover, it may provide a
-    /// recovery mechanism if (mistakenly) all super-admins have been removed.
-    ///
-    /// The return value indicates whether `account_id` was added as
-    /// super-admin.
-    ///
-    /// It is `#[private]` in the implementation provided by this trait, i.e.
-    /// only the contract itself may call this method.
-    fn acl_init_super_admin(&mut self, account_id: AccountId) -> bool;
-
     /// Returns whether `account_id` is a super-admin.
     fn acl_is_super_admin(&self, account_id: AccountId) -> bool;
 
@@ -61,13 +49,6 @@ pub trait AccessControllable {
     /// whether the predecessor was an admin for `role`.
     fn acl_renounce_admin(&mut self, role: String) -> bool;
 
-    /// Revokes admin permissions from `account_id` __without__ checking any
-    /// permissions. Returns whether `account_id` was an admin for `role`.
-    ///
-    /// This method is `#[private]` in the implementation provided by this
-    /// crate.
-    fn acl_revoke_admin_unchecked(&mut self, role: String, account_id: AccountId) -> bool;
-
     /// Grants `role` to `account_id` provided that the predecessor has
     /// sufficient permissions, i.e. is an admin as defined by [`acl_is_admin`].
     ///
@@ -75,13 +56,6 @@ pub trait AccessControllable {
     /// whether `account_id` is a new grantee of `role`. Without permissions,
     /// `None` is returned and internal state is not modified.
     fn acl_grant_role(&mut self, role: String, account_id: AccountId) -> Option<bool>;
-
-    /// Grants `role` to `account_id` __without__ checking any permissions.
-    /// Returns whether `role` was newly granted to `account_id`.
-    ///
-    /// This method is `#[private]` in the implementation provided by this
-    /// crate.
-    fn acl_grant_role_unchecked(&mut self, role: String, account_id: AccountId) -> bool;
 
     /// Returns whether `account_id` has been granted `role`.
     fn acl_has_role(&self, role: String, account_id: AccountId) -> bool;
@@ -97,13 +71,6 @@ pub trait AccessControllable {
     /// Revokes `role` from the predecessor and returns whether it was a grantee
     /// of `role`.
     fn acl_renounce_role(&mut self, role: String) -> bool;
-
-    /// Revokes `role` from `account_id` __without__ checking any permissions.
-    /// Returns whether `account_id` was a grantee of `role`.
-    ///
-    /// This method is `#[private]` in the implementation provided by this
-    /// crate.
-    fn acl_revoke_role_unchecked(&mut self, role: String, account_id: AccountId) -> bool;
 
     /// Returns whether `account_id` has been granted any of the `roles`.
     fn acl_has_any_role(&self, roles: Vec<String>, account_id: AccountId) -> bool;

--- a/near-plugins/tests/contracts/access_controllable/src/lib.rs
+++ b/near-plugins/tests/contracts/access_controllable/src/lib.rs
@@ -76,6 +76,11 @@ impl StatusMessage {
 #[near_bindgen]
 impl StatusMessage {
     #[private]
+    pub fn acl_init_super_admin(&mut self, account_id: ::near_sdk::AccountId) -> bool {
+        self.__acl.init_super_admin(&account_id)
+    }
+
+    #[private]
     pub fn acl_add_super_admin_unchecked(&mut self, account_id: AccountId) -> bool {
         self.__acl.add_super_admin_unchecked(&account_id)
     }
@@ -83,6 +88,11 @@ impl StatusMessage {
     #[private]
     pub fn acl_revoke_super_admin_unchecked(&mut self, account_id: AccountId) -> bool {
         self.__acl.revoke_super_admin_unchecked(&account_id)
+    }
+
+    #[private]
+    pub fn acl_revoke_role_unchecked(&mut self, role: Role, account_id: AccountId) -> bool {
+        self.__acl.revoke_role_unchecked(role.into(), &account_id)
     }
 
     #[private]


### PR DESCRIPTION

__Note__: To be merged after #8. Once #8 is merged I'll rebase this PR, until then the diff here on github is messy: Only the two most recent commits will remain in this PR, previous commits belong to #8.

## Overview

- Trait methods are added to `AccessControllable`:
  - `acl_grant_role`
  - `acl_revoke_role`
  - `acl_renounce_role`
  - `acl_revoke_role_unchecked`
- The attribute `#[access_controllable]` adds implementations of these methods.
- The new methods are tested in `near-plugins/tests/access_controllable.rs`

```
# Command to execute the tests:
cargo test --test access_controllable

# This makes `workspaces` write more than 1G to /tmp (on my machine).
# Depending on the size of your /tmp, a cleanup might be required afterwards.
du --summarize --total --human-readable /tmp/sandbox-*
rm -r /tmp/sandbox-*
```