### PR TITLE
Add functions acl_get_{admins, grantees}

### DIFF
--- a/near-plugins/src/access_controllable.rs
+++ b/near-plugins/src/access_controllable.rs
@@ -107,6 +107,14 @@ pub trait AccessControllable {
 
     /// Returns whether `account_id` has been granted any of the `roles`.
     fn acl_has_any_role(&self, roles: Vec<String>, account_id: AccountId) -> bool;
+
+    /// Enables paginated retrieval of admins of `role`. It returns upt to
+    /// `limit` admins and skips the first `skip` admins.
+    fn acl_get_admins(&self, role: String, skip: u64, limit: u64) -> Vec<AccountId>;
+
+    /// Enables paginated retrieval of grantees of `role`. It returns up to
+    /// `limit` grantees and skips the first `skip` grantees.
+    fn acl_get_grantees(&self, role: String, skip: u64, limit: u64) -> Vec<AccountId>;
 }
 
 pub mod events {

--- a/near-plugins/tests/access_controllable.rs
+++ b/near-plugins/tests/access_controllable.rs
@@ -640,6 +640,51 @@ async fn test_acl_has_role() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn test_acl_grant_role() -> anyhow::Result<()> {
+    let Setup {
+        worker,
+        contract,
+        account,
+        ..
+    } = Setup::new().await?;
+    let role = "LevelB";
+
+    let granter = account;
+    let grantee = worker.dev_create_account().await?;
+
+    // An account which isn't admin can't grant the role.
+    contract
+        .assert_acl_is_admin(false, role, granter.id())
+        .await;
+    let granted = contract
+        .acl_grant_role(granter.clone().into(), role, grantee.id())
+        .await?;
+    assert_eq!(granted, None);
+    contract
+        .assert_acl_has_role(false, role, grantee.id())
+        .await;
+
+    // Admin can grant the role.
+    contract
+        .acl_add_admin_unchecked(Caller::Contract, role, granter.id())
+        .await?
+        .into_result()?;
+    let granted = contract
+        .acl_grant_role(granter.clone().into(), role, grantee.id())
+        .await?;
+    assert_eq!(granted, Some(true));
+    contract.assert_acl_has_role(true, role, grantee.id()).await;
+
+    // Granting the role to an account which already is a grantee.
+    let granted = contract
+        .acl_grant_role(granter.clone().into(), role, grantee.id())
+        .await?;
+    assert_eq!(granted, Some(false));
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_acl_grant_role_unchecked() -> anyhow::Result<()> {
     let Setup {
         contract, account, ..
@@ -658,6 +703,144 @@ async fn test_acl_grant_role_unchecked() -> anyhow::Result<()> {
     // Granting a role again behaves as expected.
     let res = contract
         .acl_grant_role_unchecked(Caller::Contract, role, account.id())
+        .await?;
+    assert_success_with(res, false);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_acl_revoke_role() -> anyhow::Result<()> {
+    let setup = Setup::new().await?;
+    let role = "LevelB";
+    let grantee = setup.new_account_with_roles(&[role]).await?;
+
+    setup
+        .contract
+        .assert_acl_has_role(true, role, grantee.id())
+        .await;
+
+    // Revoke is a no-op if revoker is not an admin for the role.
+    let revoker = setup.new_account_as_admin(&[]).await?;
+    let res = setup
+        .contract
+        .acl_revoke_role(revoker.into(), role, grantee.id())
+        .await?;
+    assert_eq!(res, None);
+    let revoker = setup.new_account_as_admin(&["LevelA"]).await?;
+    let res = setup
+        .contract
+        .acl_revoke_role(revoker.into(), role, grantee.id())
+        .await?;
+    assert_eq!(res, None);
+    setup
+        .contract
+        .assert_acl_has_role(true, role, grantee.id())
+        .await;
+
+    // Revoke succeeds if the revoker is an admin for the role.
+    let revoker = setup.new_account_as_admin(&[role]).await?;
+    let res = setup
+        .contract
+        .acl_revoke_role(revoker.into(), role, grantee.id())
+        .await?;
+    assert_eq!(res, Some(true));
+    setup
+        .contract
+        .assert_acl_has_role(false, role, grantee.id())
+        .await;
+
+    // Revoking a role that isn't granted returns `Some(false)`.
+    let revoker = setup.new_account_as_admin(&[role]).await?;
+    let account = setup.worker.dev_create_account().await?;
+    let res = setup
+        .contract
+        .acl_revoke_role(revoker.into(), role, account.id())
+        .await?;
+    assert_eq!(res, Some(false));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_acl_renounce_role() -> anyhow::Result<()> {
+    let setup = Setup::new().await?;
+    let role = "LevelC";
+
+    // An account which is isn't grantee calls `acl_renounce_role`.
+    let res = setup
+        .contract
+        .acl_renounce_role(setup.account.clone().into(), role)
+        .await?;
+    assert_eq!(res, false);
+
+    // A grantee calls `acl_renounce_admin`.
+    let grantee = setup.new_account_with_roles(&[role]).await?;
+    setup
+        .contract
+        .assert_acl_has_role(true, role, grantee.id())
+        .await;
+    let res = setup
+        .contract
+        .acl_renounce_role(grantee.clone().into(), role)
+        .await?;
+    assert_eq!(res, true);
+    setup
+        .contract
+        .assert_acl_has_role(false, role, grantee.id())
+        .await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_acl_revoke_role_unchecked() -> anyhow::Result<()> {
+    let setup = Setup::new().await?;
+    let account = setup.new_account_with_roles(&["LevelA", "LevelC"]).await?;
+
+    setup
+        .contract
+        .assert_acl_has_role(true, "LevelA", account.id())
+        .await;
+    setup
+        .contract
+        .assert_acl_has_role(true, "LevelC", account.id())
+        .await;
+
+    // Revoke one of the roles.
+    let res = setup
+        .contract
+        .acl_revoke_role_unchecked(Caller::Contract, "LevelA", account.id())
+        .await?;
+    assert_success_with(res, true);
+    setup
+        .contract
+        .assert_acl_has_role(false, "LevelA", account.id())
+        .await;
+    setup
+        .contract
+        .assert_acl_has_role(true, "LevelC", account.id())
+        .await;
+
+    // Revoke the other role too.
+    let res = setup
+        .contract
+        .acl_revoke_role_unchecked(Caller::Contract, "LevelC", account.id())
+        .await?;
+    assert_success_with(res, true);
+    setup
+        .contract
+        .assert_acl_has_role(false, "LevelA", account.id())
+        .await;
+    setup
+        .contract
+        .assert_acl_has_role(false, "LevelC", account.id())
+        .await;
+
+    // Revoking behaves as expected if the role is not granted.
+    let res = setup
+        .contract
+        .acl_revoke_role_unchecked(Caller::Contract, "LevelC", account.id())
         .await?;
     assert_success_with(res, false);
 
@@ -770,6 +953,18 @@ async fn test_acl_add_admin_unchecked_is_private() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn test_acl_revoke_admin_unchecked_is_private() -> anyhow::Result<()> {
+    let Setup {
+        contract, account, ..
+    } = Setup::new().await?;
+    let res = contract
+        .acl_revoke_admin_unchecked(account.clone().into(), "LevelA", account.id())
+        .await?;
+    assert_private_method_failure(res, "acl_revoke_admin_unchecked");
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_acl_grant_role_unchecked_is_private() -> anyhow::Result<()> {
     let Setup {
         contract, account, ..
@@ -782,13 +977,13 @@ async fn test_acl_grant_role_unchecked_is_private() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn test_acl_revoke_admin_unchecked_is_private() -> anyhow::Result<()> {
+async fn test_acl_revoke_role_unchecked_is_private() -> anyhow::Result<()> {
     let Setup {
         contract, account, ..
     } = Setup::new().await?;
     let res = contract
-        .acl_revoke_admin_unchecked(account.clone().into(), "LevelA", account.id())
+        .acl_revoke_role_unchecked(account.clone().into(), "LevelA", account.id())
         .await?;
-    assert_private_method_failure(res, "acl_revoke_admin_unchecked");
+    assert_private_method_failure(res, "acl_revoke_role_unchecked");
     Ok(())
 }

--- a/near-plugins/tests/common/access_controllable_contract.rs
+++ b/near-plugins/tests/common/access_controllable_contract.rs
@@ -251,6 +251,27 @@ impl AccessControllableContract {
         assert_eq!(has_role, expected);
     }
 
+    pub async fn acl_grant_role(
+        &self,
+        caller: Caller,
+        role: &str,
+        account_id: &AccountId,
+    ) -> anyhow::Result<Option<bool>> {
+        let res = self
+            .account(caller)
+            .call(self.contract.id(), "acl_grant_role")
+            .args_json(json!({
+                "role": role,
+                "account_id": account_id,
+            }))
+            .max_gas()
+            .transact()
+            .await?
+            .into_result()?
+            .json::<Option<bool>>()?;
+        Ok(res)
+    }
+
     pub async fn acl_grant_role_unchecked(
         &self,
         caller: Caller,
@@ -259,6 +280,59 @@ impl AccessControllableContract {
     ) -> workspaces::Result<ExecutionFinalResult> {
         self.account(caller)
             .call(self.contract.id(), "acl_grant_role_unchecked")
+            .args_json(json!({
+                "role": role,
+                "account_id": account_id,
+            }))
+            .max_gas()
+            .transact()
+            .await
+    }
+
+    pub async fn acl_revoke_role(
+        &self,
+        caller: Caller,
+        role: &str,
+        account_id: &AccountId,
+    ) -> anyhow::Result<Option<bool>> {
+        let res = self
+            .account(caller)
+            .call(self.contract.id(), "acl_revoke_role")
+            .args_json(json!({
+                "role": role,
+                "account_id": account_id,
+            }))
+            .max_gas()
+            .transact()
+            .await?
+            .into_result()?
+            .json::<Option<bool>>()?;
+        Ok(res)
+    }
+
+    pub async fn acl_renounce_role(&self, caller: Caller, role: &str) -> anyhow::Result<bool> {
+        let res = self
+            .account(caller)
+            .call(self.contract.id(), "acl_renounce_role")
+            .args_json(json!({
+                "role": role,
+            }))
+            .max_gas()
+            .transact()
+            .await?
+            .into_result()?
+            .json::<bool>()?;
+        Ok(res)
+    }
+
+    pub async fn acl_revoke_role_unchecked(
+        &self,
+        caller: Caller,
+        role: &str,
+        account_id: &AccountId,
+    ) -> workspaces::Result<ExecutionFinalResult> {
+        self.account(caller)
+            .call(self.contract.id(), "acl_revoke_role_unchecked")
             .args_json(json!({
                 "role": role,
                 "account_id": account_id,

--- a/near-plugins/tests/common/access_controllable_contract.rs
+++ b/near-plugins/tests/common/access_controllable_contract.rs
@@ -341,4 +341,50 @@ impl AccessControllableContract {
             .transact()
             .await
     }
+
+    pub async fn acl_get_admins(
+        &self,
+        caller: Caller,
+        role: &str,
+        skip: u64,
+        limit: u64,
+    ) -> anyhow::Result<Vec<AccountId>> {
+        let res = self
+            .account(caller)
+            .call(self.contract.id(), "acl_get_admins")
+            .args_json(json!({
+                "role": role,
+                "skip": skip,
+                "limit": limit,
+            }))
+            .max_gas()
+            .transact()
+            .await?
+            .into_result()?
+            .json::<Vec<AccountId>>()?;
+        Ok(res)
+    }
+
+    pub async fn acl_get_grantees(
+        &self,
+        caller: Caller,
+        role: &str,
+        skip: u64,
+        limit: u64,
+    ) -> anyhow::Result<Vec<AccountId>> {
+        let res = self
+            .account(caller)
+            .call(self.contract.id(), "acl_get_grantees")
+            .args_json(json!({
+                "role": role,
+                "skip": skip,
+                "limit": limit,
+            }))
+            .max_gas()
+            .transact()
+            .await?
+            .into_result()?
+            .json::<Vec<AccountId>>()?;
+        Ok(res)
+    }
 }


### PR DESCRIPTION
__Note__ To be merged after #8 and #9. Once they are merged, I'll rebase this PR. Until then, the diff here on github is messy (hence still in draft mode). After the rebase, only the most recent commit should remain in this PR.

### Overview

Adds methods to retrieve the admins and grantees of roles.

- Trait methods are added to AccessControllable:
  - `acl_get_admins`
  - `acl_get_grantees`
- The attribute `#[access_controllable]` adds implementations of these methods.
- The new methods are tested in `near-plugins/tests/access_controllable.rs`

```
# Command to execute the tests:
cargo test --test access_controllable

# This makes `workspaces` write more than 1G to /tmp (on my machine).
# Depending on the size of your /tmp, a cleanup might be required afterwards.
du --summarize --total --human-readable /tmp/sandbox-*
rm -r /tmp/sandbox-*
```