### PR TITLE
Update syntax to pass `role_type` to acl

### DIFF
--- a/near-plugins-derive/src/access_controllable.rs
+++ b/near-plugins-derive/src/access_controllable.rs
@@ -11,7 +11,7 @@ use syn::{parse_macro_input, AttributeArgs, ItemFn, ItemStruct};
 pub struct MacroArgs {
     #[darling(default)]
     storage_prefix: Option<String>,
-    role_type: syn::Path,
+    role_type: darling::util::PathList,
 }
 
 const DEFAULT_STORAGE_PREFIX: &str = "__acl";
@@ -42,7 +42,11 @@ pub fn access_controllable(attrs: TokenStream, item: TokenStream) -> TokenStream
     let storage_prefix = macro_args
         .storage_prefix
         .unwrap_or_else(|| DEFAULT_STORAGE_PREFIX.to_string());
-    let role_type = macro_args.role_type;
+    assert!(
+        macro_args.role_type.len() == 1,
+        "role_type should be exactly one path"
+    );
+    let role_type = &macro_args.role_type[0];
 
     let output = quote! {
         #input

--- a/near-plugins/tests/contracts/access_controllable/src/lib.rs
+++ b/near-plugins/tests/contracts/access_controllable/src/lib.rs
@@ -14,7 +14,7 @@ pub enum Role {
     LevelC,
 }
 
-#[access_control(role_type = "Role")]
+#[access_control(role_type(Role))]
 #[near_bindgen]
 #[derive(Default, BorshDeserialize, BorshSerialize)]
 pub struct StatusMessage {


### PR DESCRIPTION
Currently passing the `role_type` argument into `#[access_control]` requires quotes around `Role`:

```rust
#[access_control(role_type = "Role")]
#[near_bindgen]
#[derive(Default, BorshDeserialize, BorshSerialize)]
pub struct Contract { /* ... */ }
```

Requiring quotes around the identifier looks not so nice.

After this update the quotes can be omitted and the syntax changes to:
```rust
#[access_control(role_type(Role))]
```