### PR TITLE
Make clippy check tests and fix warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,4 +50,4 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: cargo clippy
-        run: cargo clippy --all --all-features -- -D warnings
+        run: cargo clippy --all --all-features --all-targets -- -D warnings


### PR DESCRIPTION
Adding `--all-targets` makes clippy check tests. This results in a [quite a few warnings](https://github.com/aurora-is-near/near-plugins/actions/runs/3272111224/jobs/5382724238) as previously tests were ignored.

TODO: fix warnings