### PR TITLE
Add fn acl_get_super_admins to trait AccessControllable

### DIFF
--- a/near-plugins-derive/src/access_controllable.rs
+++ b/near-plugins-derive/src/access_controllable.rs
@@ -493,6 +493,14 @@ pub fn access_controllable(attrs: TokenStream, item: TokenStream) -> TokenStream
                 self.#acl_field.has_any_role(roles, &account_id)
             }
 
+            fn acl_get_super_admins(&self, skip: u64, limit: u64) -> Vec<::near_sdk::AccountId> {
+                let permission = <#bitflags_type>::from_bits(
+                    <#role_type>::acl_super_admin_permission()
+                )
+                .unwrap_or_else(|| ::near_sdk::env::panic_str(#ERR_PARSE_BITFLAG));
+                self.#acl_field.get_bearers(permission, skip, limit)
+            }
+
             fn acl_get_admins(&self, role: String, skip: u64, limit: u64) -> Vec<::near_sdk::AccountId> {
                 let role: #role_type = ::std::convert::TryFrom::try_from(role.as_str()).unwrap_or_else(|_| ::near_sdk::env::panic_str(#ERR_PARSE_ROLE));
                 let permission = <#bitflags_type>::from_bits(role.acl_admin_permission())

--- a/near-plugins/src/access_controllable.rs
+++ b/near-plugins/src/access_controllable.rs
@@ -87,7 +87,11 @@ pub trait AccessControllable {
     /// Returns whether `account_id` has been granted any of the `roles`.
     fn acl_has_any_role(&self, roles: Vec<String>, account_id: AccountId) -> bool;
 
-    /// Enables paginated retrieval of admins of `role`. It returns upt to
+    /// Enables paginated retrieval of super-admins. It returns up to `limit`
+    /// super-admins and skips the first `skip` super-admins.
+    fn acl_get_super_admins(&self, skip: u64, limit: u64) -> Vec<AccountId>;
+
+    /// Enables paginated retrieval of admins of `role`. It returns up to
     /// `limit` admins and skips the first `skip` admins.
     fn acl_get_admins(&self, role: String, skip: u64, limit: u64) -> Vec<AccountId>;
 

--- a/near-plugins/tests/common/access_controllable_contract.rs
+++ b/near-plugins/tests/common/access_controllable_contract.rs
@@ -342,6 +342,27 @@ impl AccessControllableContract {
             .await
     }
 
+    pub async fn acl_get_super_admins(
+        &self,
+        caller: Caller,
+        skip: u64,
+        limit: u64,
+    ) -> anyhow::Result<Vec<AccountId>> {
+        let res = self
+            .account(caller)
+            .call(self.contract.id(), "acl_get_super_admins")
+            .args_json(json!({
+                "skip": skip,
+                "limit": limit,
+            }))
+            .max_gas()
+            .transact()
+            .await?
+            .into_result()?
+            .json::<Vec<AccountId>>()?;
+        Ok(res)
+    }
+
     pub async fn acl_get_admins(
         &self,
         caller: Caller,


### PR DESCRIPTION
There was not method to retrieve super-admins in trait `AccessControllable`.

This PR adds `acl_get_super_admins`.