### PR TITLE
Migrate from `near_sdk::collections` to `near_sdk::store`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ keywords = ["near", "smart contract", "plugin"]
 
 [workspace.dependencies]
 bitflags = "1.3"
-near-sdk = "4.0.0"
+# Feature `unstable` is required to use `near_sdk::store`.
+near-sdk = { version = "4.0.0", features = ["unstable"] }
 near-plugins-derive = { path = "near-plugins-derive" }
 serde = "1"
 anyhow = "1.0"

--- a/near-plugins-derive/src/access_controllable.rs
+++ b/near-plugins-derive/src/access_controllable.rs
@@ -62,7 +62,7 @@ pub fn access_controllable(attrs: TokenStream, item: TokenStream) -> TokenStream
             /// Stores the set of accounts that bear a permission.
             bearers: ::near_sdk::collections::UnorderedMap<
                 #bitflags_type,
-                ::near_sdk::collections::UnorderedSet<::near_sdk::AccountId>,
+                ::near_sdk::store::UnorderedSet<::near_sdk::AccountId>,
             >,
         }
 
@@ -99,10 +99,10 @@ pub fn access_controllable(attrs: TokenStream, item: TokenStream) -> TokenStream
         }
 
         impl #acl_type {
-            fn new_bearers_set(permission: #bitflags_type) -> ::near_sdk::collections::UnorderedSet<::near_sdk::AccountId> {
+            fn new_bearers_set(permission: #bitflags_type) -> ::near_sdk::store::UnorderedSet<::near_sdk::AccountId> {
                 let base_prefix = <#ident as AccessControllable>::acl_storage_prefix();
                 let specifier = __AclStorageKey::BearersSet { permission };
-                ::near_sdk::collections::UnorderedSet::new(__acl_storage_prefix(base_prefix, specifier))
+                ::near_sdk::store::UnorderedSet::new(__acl_storage_prefix(base_prefix, specifier))
             }
 
             fn get_or_init_permissions(&self, account_id: &::near_sdk::AccountId) -> #bitflags_type {
@@ -387,7 +387,7 @@ pub fn access_controllable(attrs: TokenStream, item: TokenStream) -> TokenStream
                     Some(set) => set,
                     None => Self::new_bearers_set(permission),
                 };
-                if let true = set.insert(account_id) {
+                if let true = set.insert(account_id.clone()) {
                     self.bearers.insert(&permission, &set);
                 }
             }
@@ -405,7 +405,7 @@ pub fn access_controllable(attrs: TokenStream, item: TokenStream) -> TokenStream
                     Some(set) => set,
                     None => return vec![],
                 };
-                set.iter().skip(skip).take(limit).collect()
+                set.iter().skip(skip).take(limit).cloned().collect()
             }
 
             /// Removes `account_id` from the set of `permission` bearers.


### PR DESCRIPTION
This only affects the Acl plugin, other plugins aren't using `near_sdk::collections`.

## Motivation
`near_sdk::collections` [will be put under the legacy feature flag](https://github.com/near/near-sdk-rs/pull/923) and its successor is `near_sdk::store`. Once a contract uses a plugin based on `collections`, it will require efforts to migrate that contract to a new plugin version based on `store`. To avoid that, let's migrate `near-plugins` itself to `near_sdk::store` before any plugins are used in production.

## `near_sdk::store`
Main differences to `near_sdk::collections` are described in the last section of [this post](https://github.com/near/near-sdk-rs/discussions/829).

## Feature flag `unstable`
To use `store` it's currently still required to enable the `unstable` feature for `near_sdk`. Seems like `store` will be stabilized in sdk version 4.1 (currently it's at 4.0.0).

## Implementation details

### Usage patterns are more idiomatic for rust
For instance maps now have `get_mut` which allows removing patterns like `get element -> modify it -> write back to map`.

### Clones
Using `store` without changing any function signatures requires cloning values at various places since some `near-sdk` functions previously handling references now handle owned values and vice versa. For instance `collections::UnorderedSet::insert` has parameter `element: &T` while `store::UnorderedSet::insert` has parameter `element: T`.

A follow-up PR could change some signatures of internal functions of the Acl plugin to avoid some of these clones.

## Review
It might be more convenient to look at the commits individually.