### PR TITLE
build(deps): update near-sdk to 4.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,7 @@ keywords = ["near", "smart contract", "plugin"]
 
 [workspace.dependencies]
 bitflags = "1.3"
-# Feature `unstable` is required to use `near_sdk::store`.
-near-sdk = { version = "4.0.0", features = ["unstable"] }
+near-sdk = "4.1.0"
 near-plugins-derive = { path = "near-plugins-derive" }
 serde = "1"
 anyhow = "1.0"


### PR DESCRIPTION
Benefits:

- Stabilizes `near-sdk::store`, so `unstable` is not needed anymore for `near-sdk`.
- Includes an update that allows closing #39.

The entire near-sdk changelog is available [here](https://github.com/near/near-sdk-rs/blob/master/CHANGELOG.md).