### PR TITLE
Add Acl plugin to the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,87 @@ impl Counter {
 To upgrade the contract first call `up_stage_code` passing the binary as first argument serialized as borsh. Then call `up_deploy_code`.
 This functions must be called from the owner.
 
+### [AccessControllable](/near-plugins/src/access_controllable.rs)
+
+Enables role based access control for contract methods. A method with restricted access can only be called _successfully_ by accounts that have been granted one of the whitelisted roles. If a restricted method is called by an account with insufficient permissions it panics.
+
+Each role is managed by admins who may grant the role to accounts and revoke it from them. In addition, there are super admins that have admin permissions for every role.
+
+The sets of accounts that are (super) admins and grantees are stored in the contract's state.
+
+```rust
+/// Roles are represented by enum variants.
+/// 
+/// Deriving `AccessControlRole` ensures `Role` can be used in
+/// `AccessControllable`.
+#[derive(AccessControlRole, Deserialize, Serialize, Copy, Clone)]
+#[serde(crate = "near_sdk::serde")]
+pub enum Role {
+    SkipperByOne,
+    SkipperByAny,
+    Resetter,
+}
+
+#[access_control(role_type(Role))]
+#[near_bindgen]
+#[derive(BorshDeserialize, BorshSerialize, PanicOnDefault)]
+pub struct Contract {
+    counter: u64,
+}
+
+#[near_bindgen]
+impl Counter {
+    /// Setup access control in the constructor.
+    #[init]
+    pub fn new() -> Self {
+        let contract = Self {
+            counter: 0,
+            __acl: Default::default(), // initialize state
+        };
+
+        // Add a super admin.
+        near_sdk::require!(
+            contract.acl_init_super_admin(near_sdk::env::predecessor_account_id()),
+            "Failed to initialize super admin",
+        );
+
+        // Add an admin. This is possible since the contract was just made a
+        // super admin.
+        near_sdk::require!(
+            Some(true) == contract.acl_add_admin(Role::SkipperByOne.into(), admin_account_id),
+            "Failed to add admin",
+        );
+
+        // Grant a role. Also possible since the contract is super admin.
+        near_sdk::require!(
+            Some(true) == contract.acl_grant_role(Role::SkpperByAny.into(), grantee_account_id),
+            "Failed to grant role",
+        );
+    }
+
+    /// This method has no access control. Anyone can call it successfully.
+    pub fn increase(&mut self) {
+       self.counter += 1; 
+    }
+
+    /// Only an account which was granted any of the whitelisted roles may
+    /// successfully call this method.
+    #[access_control_any(roles(Role::SkipperByOne, Role::SkipperByAny))]
+    pub fn skip_one(&mut self) {
+        self.counter += 2;
+    }
+
+    /// Only an account which was granted `Role:Resetter` may successfully call
+    /// this method.
+    #[access_control_any(roles(Role::Resetter))]
+    pub fn reset(&mut self) {
+        self.counter = 0;
+    }
+}
+```
+
+The derived implementation of `AccessControllable` provides more methods that are documented in the [definition of the trait](/near-plugins/src/access_controllable.rs). More usage patterns are explained in [examples](/examples/access-controllable-examples/) and in [integration tests](/near-plugins/tests/access_controllable.rs).
+
 ## Contributors Notes
 
 Traits doesn't contain any implementation, even though some interfaces are self-contained enough to have it.
@@ -189,7 +270,6 @@ automatically from macros. They can be changed if the trait is manually implemen
 
 ## Roadmap
 
-- Access Control: Implement a plugin similar to [OpenZeppelin's Access Control](https://github.com/OpenZeppelin/openzeppelin-contracts/tree/master/contracts/access).
 - Factory upgrades: Allow upgrading all deployed contracts from the factory fetching binary upstream.
 - Events ergonomics. `Event` macro that can be used in the following way:
 ```rust

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ impl Counter {
             "Failed to initialize super admin",
         );
 
-        // Specify an account to be added as admin for a specifc role.
+        // Specify an account to be added as admin for a specific role.
         let skipper_by_one_admin_account_id: AccountId = "alice.near".parse().unwrap();
 
         // Add an admin for `Role::SkipperByOne`. This is possible since the


### PR DESCRIPTION
An introduction of the Acl plugin was missing - it was still listed unter Roadmap.

Closes #41