### PR TITLE
docs: Add details of Pausable integration with Acl

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Documentation of all methods provided by the derived implementation of `FullAcce
 Allow contracts to implement an emergency stop mechanism that can be triggered by an authorized account. Pauses can be
 used granularly to only limit certain features.
 
-Contract example using _Pausable_ plugin. Note that it requires the contract to be _AccessControllable_.
+Contract example using _Pausable_ plugin. Note that it requires the contract to be _AccessControllable_ in order to manage permissions. Roles allowing accounts to call certain methods can be granted and revoked via the _AccessControllable_ plugin.
 
 ```rust
 

--- a/near-plugins/src/pausable.rs
+++ b/near-plugins/src/pausable.rs
@@ -15,8 +15,10 @@
 //! by storing all paused keys in a single slot on the storage. Notice that unpausing "ALL" will not
 //! necessarily unpause all features, if other features are still present in the paused_list.
 //!
-//! Only owner and self can call `pa_pause_feature` / `pa_unpause_feature`. Requires the contract to
-//! be Ownable.
+//! As a precondition for being `Pausable` a contract must be `AccessControllable`. Access control
+//! is used to define the permissions required to pause and unpause features. In addition, grantees
+//! of access control roles may be allowed to call methods that are `#[pause]` or `#[if_paused]`
+//! unrestrictedly via the `except` argument.
 //!
 //! ## Credits:
 //!


### PR DESCRIPTION
Explain why `AccessControllable` is used and hint that it's methods should be used to grant and revoke permissions.