### PR TITLE
fix: super admin init in Pausable test contract

### DIFF
--- a/near-plugins/tests/contracts/pausable/src/lib.rs
+++ b/near-plugins/tests/contracts/pausable/src/lib.rs
@@ -46,7 +46,7 @@ impl Counter {
         // Make the contract itself super admin. This allows us to grant any role in the
         // constructor.
         near_sdk::require!(
-            contract.acl_init_super_admin(env::predecessor_account_id()),
+            contract.acl_init_super_admin(env::current_account_id()),
             "Failed to initialize super admin",
         );
 


### PR DESCRIPTION
The constructor of the test contract for `Pausable` adds the contract itself as Acl super admin. It was using `predecessor_account_id()`, though it should be `current_account_id()`.

It didn't surface as bug in integration tests since there the constructor is called by the contract itself (so predecessor id equals current account id).