### PR TITLE
chore: fix clippy errors in `near-plugins/tests`

### DIFF
--- a/near-plugins/tests/access_controllable.rs
+++ b/near-plugins/tests/access_controllable.rs
@@ -48,7 +48,7 @@ impl Setup {
     ) -> anyhow::Result<Self> {
         let worker = workspaces::sandbox().await?;
         let wasm =
-            common::repo::compile_project(&Path::new(PROJECT_PATH), "access_controllable").await?;
+            common::repo::compile_project(Path::new(PROJECT_PATH), "access_controllable").await?;
         let contract = AccessControllableContract::new(worker.dev_deploy(&wasm).await?);
         let account = worker.dev_create_account().await?;
 
@@ -171,7 +171,7 @@ async fn test_acl_is_super_admin() -> anyhow::Result<()> {
     } = Setup::new().await?;
 
     let is_super_admin = contract.acl_is_super_admin(&account, account.id()).await?;
-    assert_eq!(is_super_admin, false);
+    assert!(!is_super_admin);
 
     contract
         .acl_add_super_admin_unchecked(contract.contract().as_account(), account.id())
@@ -179,7 +179,7 @@ async fn test_acl_is_super_admin() -> anyhow::Result<()> {
         .into_result()?;
 
     let is_super_admin = contract.acl_is_super_admin(&account, account.id()).await?;
-    assert_eq!(is_super_admin, true);
+    assert!(is_super_admin);
 
     Ok(())
 }
@@ -387,7 +387,7 @@ async fn test_acl_is_admin() -> anyhow::Result<()> {
     let role = "ByMax2Increaser";
 
     let is_admin = contract.acl_is_admin(&account, role, account.id()).await?;
-    assert_eq!(is_admin, false);
+    assert!(!is_admin);
 
     contract
         .acl_add_admin_unchecked(contract_account, role, account.id())
@@ -395,7 +395,7 @@ async fn test_acl_is_admin() -> anyhow::Result<()> {
         .into_result()?;
 
     let is_admin = contract.acl_is_admin(&account, role, account.id()).await?;
-    assert_eq!(is_admin, true);
+    assert!(is_admin);
 
     Ok(())
 }
@@ -535,7 +535,7 @@ async fn test_acl_renounce_admin() -> anyhow::Result<()> {
         .contract
         .acl_renounce_admin(&setup.account, role)
         .await?;
-    assert_eq!(res, false);
+    assert!(!res);
 
     // An admin calls `acl_renounce_admin`.
     let admin = setup.new_account_as_admin(&[role]).await?;
@@ -544,7 +544,7 @@ async fn test_acl_renounce_admin() -> anyhow::Result<()> {
         .assert_acl_is_admin(true, role, admin.id())
         .await;
     let res = setup.contract.acl_renounce_admin(&admin, role).await?;
-    assert_eq!(res, true);
+    assert!(res);
     setup
         .contract
         .assert_acl_is_admin(false, role, admin.id())
@@ -618,7 +618,7 @@ async fn test_acl_has_role() -> anyhow::Result<()> {
     let role = "ByMax2Increaser";
 
     let has_role = contract.acl_has_role(&account, role, account.id()).await?;
-    assert_eq!(has_role, false);
+    assert!(!has_role);
 
     contract
         .acl_grant_role_unchecked(contract_account, role, account.id())
@@ -626,7 +626,7 @@ async fn test_acl_has_role() -> anyhow::Result<()> {
         .into_result()?;
 
     let has_role = contract.acl_has_role(&account, role, account.id()).await?;
-    assert_eq!(has_role, true);
+    assert!(has_role);
 
     Ok(())
 }
@@ -766,7 +766,7 @@ async fn test_acl_renounce_role() -> anyhow::Result<()> {
         .contract
         .acl_renounce_role(&setup.account, role)
         .await?;
-    assert_eq!(res, false);
+    assert!(!res);
 
     // A grantee calls `acl_renounce_admin`.
     let grantee = setup.new_account_with_roles(&[role]).await?;
@@ -775,7 +775,7 @@ async fn test_acl_renounce_role() -> anyhow::Result<()> {
         .assert_acl_has_role(true, role, grantee.id())
         .await;
     let res = setup.contract.acl_renounce_role(&grantee, role).await?;
-    assert_eq!(res, true);
+    assert!(res);
     setup
         .contract
         .assert_acl_has_role(false, role, grantee.id())

--- a/near-plugins/tests/common/utils.rs
+++ b/near-plugins/tests/common/utils.rs
@@ -29,8 +29,7 @@ where
 pub fn assert_private_method_failure(res: ExecutionFinalResult, method: &str) {
     let err = res
         .into_result()
-        .err()
-        .expect("Transaction should have failed");
+        .expect_err("Transaction should have failed");
     let err = format!("{}", err);
     let must_contain = format!("Method {} is private", method);
     assert!(
@@ -50,8 +49,7 @@ pub fn assert_insufficient_acl_permissions(
 ) {
     let err = res
         .into_result()
-        .err()
-        .expect("Transaction should have failed");
+        .expect_err("Transaction should have failed");
     let err = format!("{}", err);
 
     // TODO fix escaping issue to also verify second sentence of the error
@@ -73,12 +71,11 @@ pub fn assert_insufficient_acl_permissions(
 pub fn assert_method_is_paused(res: ExecutionFinalResult) {
     let err = res
         .into_result()
-        .err()
-        .expect("Transaction should have failed");
+        .expect_err("Transaction should have failed");
     let err = format!("{}", err);
     let must_contain = "Pausable: Method is paused";
     assert!(
-        err.contains(&must_contain),
+        err.contains(must_contain),
         "Expected method to be paused, instead it failed with: {}",
         err
     );
@@ -87,12 +84,11 @@ pub fn assert_method_is_paused(res: ExecutionFinalResult) {
 pub fn assert_owner_update_failure(res: ExecutionFinalResult) {
     let err = res
         .into_result()
-        .err()
-        .expect("Transaction should have failed");
+        .expect_err("Transaction should have failed");
     let err = format!("{}", err);
     let must_contain = "Ownable: Only owner can update current owner";
     assert!(
-        err.contains(&must_contain),
+        err.contains(must_contain),
         "Expected failure due to caller not being owner, instead it failed with: {}",
         err
     );
@@ -102,12 +98,11 @@ pub fn assert_owner_update_failure(res: ExecutionFinalResult) {
 pub fn assert_ownable_permission_failure(res: ExecutionFinalResult) {
     let err = res
         .into_result()
-        .err()
-        .expect("Transaction should have failed");
+        .expect_err("Transaction should have failed");
     let err = format!("{}", err);
     let must_contain = "Method is private";
     assert!(
-        err.contains(&must_contain),
+        err.contains(must_contain),
         "Expected failure due to insufficient permissions, instead it failed with: {}",
         err
     );
@@ -118,12 +113,11 @@ pub fn assert_ownable_permission_failure(res: ExecutionFinalResult) {
 pub fn assert_only_owner_permission_failure(res: ExecutionFinalResult) {
     let err = res
         .into_result()
-        .err()
-        .expect("Transaction should have failed");
+        .expect_err("Transaction should have failed");
     let err = format!("{}", err);
     let must_contain = "Ownable: Method must be called from owner";
     assert!(
-        err.contains(&must_contain),
+        err.contains(must_contain),
         "Expected failure due to caller not being owner, instead it failed with: {}",
         err
     );
@@ -133,8 +127,7 @@ pub fn assert_only_owner_permission_failure(res: ExecutionFinalResult) {
 pub fn assert_failure_with(res: ExecutionFinalResult, must_contain: &str) {
     let err = res
         .into_result()
-        .err()
-        .expect("Transaction should have failed");
+        .expect_err("Transaction should have failed");
     let err = format!("{}", err);
     assert!(
         err.contains(must_contain),

--- a/near-plugins/tests/pausable.rs
+++ b/near-plugins/tests/pausable.rs
@@ -42,7 +42,7 @@ impl Setup {
     async fn new() -> anyhow::Result<Self> {
         // Compile and deploy the contract.
         let worker = workspaces::sandbox().await?;
-        let wasm = common::repo::compile_project(&Path::new(PROJECT_PATH), "pausable").await?;
+        let wasm = common::repo::compile_project(Path::new(PROJECT_PATH), "pausable").await?;
         let contract = worker.dev_deploy(&wasm).await?;
         let pausable_contract = PausableContract::new(contract.clone());
         let acl_contract = AccessControllableContract::new(contract.clone());
@@ -324,7 +324,7 @@ async fn assert_paused_list(
     contract: &PausableContract,
     caller: &Account,
 ) {
-    let paused_list = contract.pa_all_paused(&caller).await.unwrap();
+    let paused_list = contract.pa_all_paused(caller).await.unwrap();
     assert_eq!(paused_list, expected);
 }
 
@@ -474,7 +474,7 @@ async fn test_pause_except_ok() -> anyhow::Result<()> {
     // Grantee of `Role::Unrestricted4Increaser` is exempted.
     let increaser = setup.worker.dev_create_account().await?;
     setup
-        .must_grant_acl_role("Unrestricted4Increaser", &increaser.id())
+        .must_grant_acl_role("Unrestricted4Increaser", increaser.id())
         .await;
     let res = setup
         .call_counter_modifier(&increaser, "increase_4")
@@ -485,7 +485,7 @@ async fn test_pause_except_ok() -> anyhow::Result<()> {
     // Grantee of `Role::Unrestricted4Modifier` is exempted.
     let modifier = setup.worker.dev_create_account().await?;
     setup
-        .must_grant_acl_role("Unrestricted4Modifier", &modifier.id())
+        .must_grant_acl_role("Unrestricted4Modifier", modifier.id())
         .await;
     let res = setup.call_counter_modifier(&modifier, "increase_4").await?;
     assert_success_with_unit_return(res);


### PR DESCRIPTION
This PR fixes errors found by clippy when run on `near-plugins/tests`. Currently CI is not checking tests, see #23. Once this PR is merged, we can merge #23 to make CI check tests.

The errors fixed here were found with the following command:

```
cargo clippy --all --all-features --all-targets -- -D warnings
```