### PR TITLE
ci: make clippy check tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,4 +50,4 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: cargo clippy
-        run: cargo clippy --all --all-features -- -D warnings
+        run: cargo clippy --all --all-features --all-targets -- -D warnings


### PR DESCRIPTION
Previously clippy did not check tests. There were some issues which have been fixed in #63.