### PR TITLE
build(deps): bump `workspaces` from `0.6` to `0.7`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,7 @@ serde = "1"
 anyhow = "1.0"
 borsh = "0.9"
 tokio = { version = "1", features = ["full"] }
-# Feature `unstable` is required for compiling contracts during tests.
-workspaces = { version = "0.6", features = ["unstable"] }
+workspaces = "0.7"
 toml = "0.5"
 darling = "0.13.1"
 proc-macro2 = "1.0"


### PR DESCRIPTION
This allows to [view_access_keys](https://docs.rs/workspaces/0.7.0/workspaces/struct.Contract.html#method.view_access_keys) of a `Contract`, which is helpful for testing `FullAccessKeyFallback::attach_full_access_key`.

Other changes in `workspaces` require no action items for this repo.

---

Feature `unstable` can be removed since we’re no longer using `workspaces::compile_project` (#15).