### PR TITLE
feat(AccessControllable): add `acl_get_permissioned_accounts`

### DIFF
--- a/near-plugins/tests/access_controllable.rs
+++ b/near-plugins/tests/access_controllable.rs
@@ -4,10 +4,12 @@ pub mod common;
 
 use common::access_controllable_contract::AccessControllableContract;
 use common::utils::{
-    assert_insufficient_acl_permissions, assert_private_method_failure, assert_success_with,
+    as_sdk_account_id, assert_insufficient_acl_permissions, assert_private_method_failure,
+    assert_success_with,
 };
+use near_plugins::access_controllable::{PermissionedAccounts, PermissionedAccountsPerRole};
 use near_sdk::serde_json::json;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
 use std::path::Path;
 use workspaces::network::Sandbox;
@@ -115,6 +117,82 @@ async fn call_increase_2(
         .max_gas()
         .transact()
         .await
+}
+
+/// Returns new `PermissionedAccounts` for [`ALL_ROLES`].
+fn new_permissioned_accounts() -> PermissionedAccounts {
+    let mut permissioned_accounts = PermissionedAccounts {
+        super_admins: vec![],
+        roles: HashMap::new(),
+    };
+
+    for role in ALL_ROLES {
+        permissioned_accounts.roles.insert(
+            role.to_string(),
+            PermissionedAccountsPerRole {
+                admins: vec![],
+                grantees: vec![],
+            },
+        );
+    }
+
+    permissioned_accounts
+}
+
+/// Asserts both `PermissionedAcccounts` contain the same accounts with the same permissions,
+/// disregarding order.
+///
+/// Expects both `a` and `b` to contain every role in [`ALL_ROLES`].
+///
+/// This function is available only in tests and used for small numbers of accounts, so simplicity
+/// is favored over efficiency.
+fn assert_permissioned_account_equivalence(a: &PermissionedAccounts, b: &PermissionedAccounts) {
+    // Verify super admins.
+    assert_account_ids_equivalence(
+        a.super_admins.as_slice(),
+        b.super_admins.as_slice(),
+        "super_admins",
+    );
+
+    // Verify admins and grantees per role.
+    assert_eq!(a.roles.len(), b.roles.len(), "Unequal number of roles");
+    assert_eq!(a.roles.len(), ALL_ROLES.len(), "More roles than expected");
+    for role in ALL_ROLES {
+        let per_role_a = a
+            .roles
+            .get(role)
+            .unwrap_or_else(|| panic!("PermissionedAccounts a misses role {}", role));
+        let per_role_b = b
+            .roles
+            .get(role)
+            .unwrap_or_else(|| panic!("PermissionedAccounts b misses role {}", role));
+
+        assert_account_ids_equivalence(
+            &per_role_a.admins,
+            &per_role_b.admins,
+            format!("admins of role {}", role).as_str(),
+        );
+        assert_account_ids_equivalence(
+            &per_role_a.grantees,
+            &per_role_b.grantees,
+            format!("grantees of role {}", role).as_str(),
+        );
+    }
+}
+
+/// Asserts `a` and `b` contain the same `AccountId`s, disregarding order. Parameter `specifier` is
+/// passed to the panic message in case of a mismatch.
+///
+/// This function is available only in tests and used for small numbers of accounts, so simplicity
+/// is favored over efficiency.
+fn assert_account_ids_equivalence(
+    a: &[near_sdk::AccountId],
+    b: &[near_sdk::AccountId],
+    specifier: &str,
+) {
+    let set_a: HashSet<_> = a.iter().cloned().collect();
+    let set_b: HashSet<_> = b.iter().cloned().collect();
+    assert_eq!(set_a, set_b, "Unequal sets of AccountIds for {}", specifier,);
 }
 
 /// Smoke test of contract setup and basic functionality.
@@ -1121,6 +1199,68 @@ async fn test_acl_get_grantees() -> anyhow::Result<()> {
         .acl_get_grantees(&setup.account, role, 0, 4)
         .await?;
     assert_eq!(actual, grantee_ids);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_acl_get_permissioned_accounts() -> anyhow::Result<()> {
+    let setup = Setup::new().await?;
+
+    // Verify returned `PermissionedAccounts` are empty when there are no outstanding permissions.
+    let permissioned_accounts = setup
+        .contract
+        .acl_get_permissioned_accounts(&setup.account)
+        .await?;
+    let mut expected = new_permissioned_accounts();
+    assert_permissioned_account_equivalence(&permissioned_accounts, &expected);
+
+    // Add a super admin to the contract's Acl.
+    let super_admin = setup.worker.dev_create_account().await?;
+    let res = setup
+        .contract
+        .acl_init_super_admin(setup.contract_account(), super_admin.id())
+        .await?;
+    assert_success_with(res, true);
+
+    // Add admins and grantees to the contract's Acl.
+    let admin_0 = setup.new_account_as_admin(&[ALL_ROLES[0]]).await?;
+    let admin_2 = setup.new_account_as_admin(&[ALL_ROLES[2]]).await?;
+    let grantee_1_a = setup.new_account_with_roles(&[ALL_ROLES[1]]).await?;
+    let grantee_1_b = setup.new_account_with_roles(&[ALL_ROLES[1]]).await?;
+
+    // Insert ids added to contract's Acl into `expected`.
+    expected
+        .super_admins
+        .push(as_sdk_account_id(super_admin.id()));
+    expected
+        .roles
+        .get_mut(ALL_ROLES[0])
+        .unwrap()
+        .admins
+        .push(as_sdk_account_id(admin_0.id()));
+    expected
+        .roles
+        .get_mut(ALL_ROLES[1])
+        .unwrap()
+        .grantees
+        .extend([
+            as_sdk_account_id(grantee_1_a.id()),
+            as_sdk_account_id(grantee_1_b.id()),
+        ]);
+    expected
+        .roles
+        .get_mut(ALL_ROLES[2])
+        .unwrap()
+        .admins
+        .push(as_sdk_account_id(admin_2.id()));
+
+    // Verify returned `PermissionedAccounts` when there are outstanding permissions.
+    let permissioned_accounts = setup
+        .contract
+        .acl_get_permissioned_accounts(&setup.account)
+        .await?;
+    assert_permissioned_account_equivalence(&permissioned_accounts, &expected);
 
     Ok(())
 }

--- a/near-plugins/tests/common/access_controllable_contract.rs
+++ b/near-plugins/tests/common/access_controllable_contract.rs
@@ -1,3 +1,5 @@
+use near_plugins::access_controllable::PermissionedAccounts;
+
 use near_sdk::serde_json::json;
 use workspaces::result::ExecutionFinalResult;
 use workspaces::{Account, AccountId, Contract};
@@ -383,5 +385,16 @@ impl AccessControllableContract {
             .into_result()?
             .json::<Vec<AccountId>>()?;
         Ok(res)
+    }
+
+    pub async fn acl_get_permissioned_accounts(
+        &self,
+        caller: &Account,
+    ) -> anyhow::Result<PermissionedAccounts> {
+        let res = caller
+            .call(self.contract.id(), "acl_get_permissioned_accounts")
+            .view()
+            .await?;
+        Ok(res.json::<PermissionedAccounts>()?)
     }
 }

--- a/near-plugins/tests/common/utils.rs
+++ b/near-plugins/tests/common/utils.rs
@@ -1,7 +1,17 @@
 use near_sdk::serde::de::DeserializeOwned;
 use std::cmp::PartialEq;
 use std::fmt::Debug;
+use std::str::FromStr;
 use workspaces::result::ExecutionFinalResult;
+use workspaces::AccountId;
+
+/// Converts `account_id` to a `near_sdk::AccountId` and panics on failure.
+///
+/// Only available in tests, hence favoring simplicity over efficiency.
+pub fn as_sdk_account_id(account_id: &AccountId) -> near_sdk::AccountId {
+    near_sdk::AccountId::from_str(account_id.as_str())
+        .expect("Conversion to near_sdk::AccountId should succeed")
+}
 
 /// Asserts execution was successful and returned `()`.
 pub fn assert_success_with_unit_return(res: ExecutionFinalResult) {


### PR DESCRIPTION
Adds method `acl_get_permissioned_accounts` which returns information about _all_ outstanding permissions.

This method will be available on every contract that implements `AccessControllable`.