### PR TITLE
ci: switch to self hosted runners

### DIFF
--- a/.github/workflows/contract-analysis.yml
+++ b/.github/workflows/contract-analysis.yml
@@ -12,5 +12,6 @@ name: "Contract Security Analysis"
 jobs:
   contract_analysis:
     name: "Shared"
+    runs-on: self-hosted
     uses: aurora-is-near/.github/.github/workflows/contract_analysis.yml@master
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-
       - uses: Swatinem/rust-cache@v1
         with:
           cache-on-failure: true
@@ -35,12 +30,6 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   tests:
     name: Tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
 
   lint:
     name: Format
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3


### PR DESCRIPTION
Run CI jobs on self hosted runners instead of runners provided by Github.