### PR TITLE
test(Upgradable): transact with contract after deployment

### DIFF
--- a/near-plugins-derive/tests/contracts/upgradable_2/Cargo.toml
+++ b/near-plugins-derive/tests/contracts/upgradable_2/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "upgradable_2"
+version = "0.0.0"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+near-plugins = { path = "../../../../near-plugins" }
+near-sdk = "4.1.0"
+
+[profile.release]
+codegen-units = 1
+opt-level = "z"
+lto = true
+debug = false
+panic = "abort"
+overflow-checks = true
+
+[workspace]

--- a/near-plugins-derive/tests/contracts/upgradable_2/Makefile
+++ b/near-plugins-derive/tests/contracts/upgradable_2/Makefile
@@ -1,0 +1,8 @@
+build:
+	cargo build --target wasm32-unknown-unknown --release
+
+# Helpful for debugging. Requires `cargo-expand`.
+expand:
+	cargo expand > expanded.rs
+
+.PHONY: build expand

--- a/near-plugins-derive/tests/contracts/upgradable_2/rust-toolchain
+++ b/near-plugins-derive/tests/contracts/upgradable_2/rust-toolchain
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.66.1"
+components = ["clippy", "rustfmt"]

--- a/near-plugins-derive/tests/contracts/upgradable_2/src/lib.rs
+++ b/near-plugins-derive/tests/contracts/upgradable_2/src/lib.rs
@@ -1,0 +1,22 @@
+//! A simple contract to be deployed via `Upgradable`.
+
+use near_plugins::{Ownable, Upgradable};
+use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
+use near_sdk::{near_bindgen, PanicOnDefault};
+
+/// The struct is the same as in the initial contract `../upgradable`, so no [state migration] is
+/// required.
+///
+/// [state migration]: https://docs.near.org/develop/upgrade#migrating-the-state
+#[near_bindgen]
+#[derive(Ownable, Upgradable, PanicOnDefault, BorshDeserialize, BorshSerialize)]
+pub struct Contract;
+
+#[near_bindgen]
+impl Contract {
+    /// A method that is _not_ defined in the initial contract, so its existence proves the
+    /// contract defined in this file was deployed.
+    pub fn is_upgraded() -> bool {
+        true
+    }
+}


### PR DESCRIPTION
Adds a test sending a transaction to a contract that was upgraded using `Upgradable`. The new version of the contract is located in `near-plugins-derive/tests/contracts/upgradable_2`.