### PR TITLE
feat(Upgradable)!: use Acl for authorization 

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ Documentation of all methods provided by `Pausable` is available in the [definit
 
 ### [Upgradable](/near-plugins/src/upgradable.rs)
 
-Allows a contract to be upgraded by the owner without requiring a full access key. Optionally a staging duration can be set, which defines the minimum duration that must pass before staged code can be deployed. The staging duration is a safety mechanism to protect users that interact with the contract, giving them time to opt-out before an unfavorable update is deployed.
+Allows a contract to be upgraded without requiring a full access key. Optionally a staging duration can be set, which defines the minimum duration that must pass before staged code can be deployed. The staging duration is a safety mechanism to protect users that interact with the contract, giving them time to opt-out before an unfavorable update is deployed.
 
-Using the `Upgradable` plugin requires a contract to be `Ownable`.
+Using the `Upgradable` plugin requires a contract to be `AccessControllable` to handle authorization for calling `Upgradable` methods to stage or deploy updates (listed below). 
 
-To upgrade the contract first call `up_stage_code` passing the binary as first argument serialized as borsh. Then call `up_deploy_code`. Both functions must be called by the owner of the contract.
+To upgrade the contract, first call `up_stage_code` passing the binary as first argument serialized as borsh. Then call `up_deploy_code`.
 
-To set a staging duration, call `up_stage_init_staging_duration`. After initialization the staging duration can be updated by calling `up_stage_update_staging_duration` followed by `up_apply_update_staging_duration`. Updating the staging duration is itself subject to a delay: at least the currently set staging duration must pass before a staged update can be applied. The functions mentioned in this paragraph must be called by the owner of the contract.
+To set a staging duration, call `up_init_staging_duration`. After initialization the staging duration can be updated by calling `up_stage_update_staging_duration` followed by `up_apply_update_staging_duration`. Updating the staging duration is itself subject to a delay: at least the currently set staging duration must pass before a staged update can be applied.
 
 [This contract](/near-plugins-derive/tests/contracts/upgradable/src/lib.rs) provides an example of using `Upgradable`. It is compiled, deployed on chain and interacted with in [integration tests](/near-plugins-derive/tests/upgradable.rs).
 

--- a/near-plugins-derive/tests/contracts/upgradable/src/lib.rs
+++ b/near-plugins-derive/tests/contracts/upgradable/src/lib.rs
@@ -26,9 +26,7 @@ pub enum Role {
     duration_update_stagers(Role::DurationManager, Role::DAO),
     duration_update_appliers(Role::DurationManager, Role::DAO),
 ))]
-pub struct Contract {
-    dummy: u64, // TODO remove after `__acl` field was removed (#84)
-}
+pub struct Contract;
 
 #[near_bindgen]
 impl Contract {
@@ -48,10 +46,7 @@ impl Contract {
     /// deployment in a batch transaction.
     #[init]
     pub fn new(dao: Option<AccountId>, staging_duration: Option<Duration>) -> Self {
-        let mut contract = Self {
-            dummy: 0,
-            __acl: Default::default(), // TODO remove after merging #84
-        };
+        let mut contract = Self;
 
         // Make the contract itself access control super admin, allowing it to grant and revoke
         // permissions.

--- a/near-plugins-derive/tests/contracts/upgradable/src/lib.rs
+++ b/near-plugins-derive/tests/contracts/upgradable/src/lib.rs
@@ -52,12 +52,17 @@ impl Contract {
             __acl: Default::default(), // TODO remove after merging #84
         };
 
+        // Make the contract itself access control super admin, allowing it to grant and revoke
+        // permissions.
+        near_sdk::require!(
+            contract.acl_init_super_admin(env::current_account_id()),
+            "Failed to initialize super admin",
+        );
+
+        // Optionally grant `Role::DAO`.
         if let Some(account_id) = dao {
-            // TODO add warning regarding `*_unchecked()`
-            let res = contract
-                .__acl
-                .grant_role_unchecked(Role::DAO.into(), &account_id);
-            assert_eq!(true, res, "Failed to grant role");
+            let res = contract.acl_grant_role(Role::DAO.into(), account_id);
+            assert_eq!(Some(true), res, "Failed to grant role");
         }
 
         // Optionally initialize the staging duration.

--- a/near-plugins-derive/tests/contracts/upgradable/src/lib.rs
+++ b/near-plugins-derive/tests/contracts/upgradable/src/lib.rs
@@ -84,18 +84,12 @@ impl Contract {
 
         // Optionally initialize the staging duration.
         if let Some(staging_duration) = staging_duration {
-            // TODO grant DurationManager, call init_dur, revoke DurationManager
-            // To get rid of _unchecked method
-            // The owner (set above) might be an account other than the contract itself. In that
-            // case `Upgradable::up_init_staging_duration` would fail, since only the Owner may call
-            // it successfully. Therefore we are using an (internal) unchecked method here.
-            //
-            // Avoid using `*_unchecked` functions in public contract methods that are not protected
-            // by access control. Otherwise there is a risk of unwanted state changes carried out by
-            // malicious users. For this example, we assume the constructor is called in a batch
-            // transaction together with code deployment.
-            // TODO try using up_init_staging_duration
-            contract.up_set_staging_duration_unchecked(staging_duration);
+            // Temporarily grant `Role::DurationManager` to the contract to authorize it for
+            // initializing the staging duration. Granting and revoking the role is possible since
+            // the contract was made super admin above.
+            contract.acl_grant_role(Role::DurationManager.into(), env::current_account_id());
+            contract.up_init_staging_duration(staging_duration);
+            contract.acl_revoke_role(Role::DurationManager.into(), env::current_account_id());
         }
 
         contract

--- a/near-plugins-derive/tests/contracts/upgradable/src/lib.rs
+++ b/near-plugins-derive/tests/contracts/upgradable/src/lib.rs
@@ -1,14 +1,37 @@
-use near_plugins::{Ownable, Upgradable};
+use near_plugins::{access_control, AccessControlRole, AccessControllable, Upgradable};
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
+use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::{near_bindgen, AccountId, Duration, PanicOnDefault};
 
-/// Deriving `Upgradable` requires the contract to be `Ownable.`
+// TODO add doc comments
+#[derive(AccessControlRole, Deserialize, Serialize, Copy, Clone)]
+#[serde(crate = "near_sdk::serde")]
+pub enum Role {
+    // May do anything
+    DAO,
+    CodeStager,
+    CodeDeployer,
+    DurationManager,
+}
+
+/// Deriving `Upgradable` requires the contract to be `AccessControllable`.
+#[access_control(role_type(Role))]
 #[near_bindgen]
-#[derive(Ownable, Upgradable, PanicOnDefault, BorshDeserialize, BorshSerialize)]
-pub struct Contract;
+#[derive(Upgradable, PanicOnDefault, BorshDeserialize, BorshSerialize)]
+#[upgradable(access_control_roles(
+    code_stagers(Role::CodeStager, Role::DAO),
+    code_deployers(Role::CodeDeployer, Role::DAO),
+    duration_initializers(Role::DurationManager, Role::DAO),
+    duration_update_stagers(Role::DurationManager, Role::DAO),
+    duration_update_appliers(Role::DurationManager, Role::DAO),
+))]
+pub struct Contract {
+    dummy: u64, // TODO remove after `__acl` field was removed (#84)
+}
 
 #[near_bindgen]
 impl Contract {
+    // TODO update docs and comments
     /// Parameter `owner` allows setting the owner in the constructor if an `AccountId` is provided.
     /// If `owner` is `None`, no owner will be set in the constructor. After contract initialization
     /// it is possible to set an owner with `Ownable::owner_set`.
@@ -23,12 +46,18 @@ impl Contract {
     /// Since this constructor uses an `*_unchecked` method, it should be combined with code
     /// deployment in a batch transaction.
     #[init]
-    pub fn new(owner: Option<AccountId>, staging_duration: Option<Duration>) -> Self {
-        let mut contract = Self;
+    pub fn new(dao: Option<AccountId>, staging_duration: Option<Duration>) -> Self {
+        let mut contract = Self {
+            dummy: 0,
+            __acl: Default::default(), // TODO remove after merging #84
+        };
 
-        // Optionally set the owner.
-        if owner.is_some() {
-            contract.owner_set(owner);
+        if let Some(account_id) = dao {
+            // TODO add warning regarding `*_unchecked()`
+            let res = contract
+                .__acl
+                .grant_role_unchecked(Role::DAO.into(), &account_id);
+            assert_eq!(true, res, "Failed to grant role");
         }
 
         // Optionally initialize the staging duration.
@@ -41,6 +70,7 @@ impl Contract {
             // by access control. Otherwise there is a risk of unwanted state changes carried out by
             // malicious users. For this example, we assume the constructor is called in a batch
             // transaction together with code deployment.
+            // TODO try using up_init_staging_duration
             contract.up_set_staging_duration_unchecked(staging_duration);
         }
 

--- a/near-plugins-derive/tests/contracts/upgradable/src/lib.rs
+++ b/near-plugins-derive/tests/contracts/upgradable/src/lib.rs
@@ -1,5 +1,6 @@
 use near_plugins::{access_control, AccessControlRole, AccessControllable, Upgradable};
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
+use near_sdk::env;
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::{near_bindgen, AccountId, Duration, PanicOnDefault};
 
@@ -67,6 +68,8 @@ impl Contract {
 
         // Optionally initialize the staging duration.
         if let Some(staging_duration) = staging_duration {
+            // TODO grant DurationManager, call init_dur, revoke DurationManager
+            // To get rid of _unchecked method
             // The owner (set above) might be an account other than the contract itself. In that
             // case `Upgradable::up_init_staging_duration` would fail, since only the Owner may call
             // it successfully. Therefore we are using an (internal) unchecked method here.
@@ -80,5 +83,10 @@ impl Contract {
         }
 
         contract
+    }
+
+    /// Function to verify the contract was deployed and initialized successfully.
+    pub fn is_set_up(&self) -> bool {
+        true
     }
 }

--- a/near-plugins-derive/tests/contracts/upgradable_2/src/lib.rs
+++ b/near-plugins-derive/tests/contracts/upgradable_2/src/lib.rs
@@ -30,9 +30,7 @@ pub enum Role {
     duration_update_stagers(Role::DurationManager, Role::DAO),
     duration_update_appliers(Role::DurationManager, Role::DAO),
 ))]
-pub struct Contract {
-    dummy: u64, // TODO remove after `__acl` was remove field removed (#84)
-}
+pub struct Contract;
 
 #[near_bindgen]
 impl Contract {

--- a/near-plugins-derive/tests/contracts/upgradable_2/src/lib.rs
+++ b/near-plugins-derive/tests/contracts/upgradable_2/src/lib.rs
@@ -1,16 +1,38 @@
 //! A simple contract to be deployed via `Upgradable`.
 
-use near_plugins::{Ownable, Upgradable};
+use near_plugins::{access_control, AccessControlRole, AccessControllable, Upgradable};
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
+use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::{near_bindgen, PanicOnDefault};
+
+/// Roles correspond to those defined in the initial contract `../upgradable`, to make permissions
+/// granted before the upgrade remain valid.
+#[derive(AccessControlRole, Deserialize, Serialize, Copy, Clone)]
+#[serde(crate = "near_sdk::serde")]
+pub enum Role {
+    DAO,
+    CodeStager,
+    CodeDeployer,
+    DurationManager,
+}
 
 /// The struct is the same as in the initial contract `../upgradable`, so no [state migration] is
 /// required.
 ///
 /// [state migration]: https://docs.near.org/develop/upgrade#migrating-the-state
+#[access_control(role_type(Role))]
 #[near_bindgen]
-#[derive(Ownable, Upgradable, PanicOnDefault, BorshDeserialize, BorshSerialize)]
-pub struct Contract;
+#[derive(Upgradable, PanicOnDefault, BorshDeserialize, BorshSerialize)]
+#[upgradable(access_control_roles(
+    code_stagers(Role::CodeStager, Role::DAO),
+    code_deployers(Role::CodeDeployer, Role::DAO),
+    duration_initializers(Role::DurationManager, Role::DAO),
+    duration_update_stagers(Role::DurationManager, Role::DAO),
+    duration_update_appliers(Role::DurationManager, Role::DAO),
+))]
+pub struct Contract {
+    dummy: u64, // TODO remove after `__acl` was remove field removed (#84)
+}
 
 #[near_bindgen]
 impl Contract {

--- a/near-plugins-derive/tests/upgradable.rs
+++ b/near-plugins-derive/tests/upgradable.rs
@@ -807,7 +807,7 @@ async fn test_acl_permission_scope() -> anyhow::Result<()> {
     let code_stager = worker.dev_create_account().await?;
     let granted = setup
         .acl_contract
-        .acl_grant_role(&setup.contract.as_account(), "CodeStager", code_stager.id())
+        .acl_grant_role(setup.contract.as_account(), "CodeStager", code_stager.id())
         .await?;
     assert_eq!(Some(true), granted);
 


### PR DESCRIPTION
Previously `Upgradable` authorization was handled by `Ownable`. An explanation of how to use `Upgradable` with Acl is available in the [example contract](https://github.com/aurora-is-near/near-plugins/blob/d5096361fa42ea21b82f0d071497400f357919eb/near-plugins-derive/tests/contracts/upgradable/src/lib.rs).

# Acl Roles
Use cases which don’t require fine grained permissions can define only a single role and whitelist it for all `Upgradable` features. See `Role::DAO` in the example contract.

The other roles show how to achieve more fine grained permissions by whitelisting a role only for a subset of the `Upgradable` features.