### PR TITLE
feat(Upgradable)!: enable batched fn call after deploy

### DIFF
--- a/near-plugins-derive/tests/common/upgradable_contract.rs
+++ b/near-plugins-derive/tests/common/upgradable_contract.rs
@@ -1,4 +1,4 @@
-use near_plugins::upgradable::UpgradableDurationStatus;
+use near_plugins::upgradable::{FunctionCallArgs, UpgradableDurationStatus};
 
 use near_sdk::serde_json::json;
 use near_sdk::CryptoHash;
@@ -71,9 +71,13 @@ impl UpgradableContract {
     pub async fn up_deploy_code(
         &self,
         caller: &Account,
+        function_call_args: Option<FunctionCallArgs>,
     ) -> workspaces::Result<ExecutionFinalResult> {
         caller
             .call(self.contract.id(), "up_deploy_code")
+            .args_json(json!({
+                "function_call_args": function_call_args,
+            }))
             .max_gas()
             .transact()
             .await

--- a/near-plugins-derive/tests/common/utils.rs
+++ b/near-plugins-derive/tests/common/utils.rs
@@ -49,6 +49,11 @@ where
     assert_eq!(actual, expected);
 }
 
+/// Asserts transaction failure due `MethodNotFound` error.
+pub fn assert_method_not_found_failure(res: ExecutionFinalResult) {
+    assert_failure_with(res, "Action #0: MethodResolveError(MethodNotFound)");
+}
+
 /// Asserts transaction failure due to `method` being `#[private]`.
 pub fn assert_private_method_failure(res: ExecutionFinalResult, method: &str) {
     let err = res

--- a/near-plugins-derive/tests/contracts/upgradable_state_migration/Cargo.toml
+++ b/near-plugins-derive/tests/contracts/upgradable_state_migration/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "upgradable_state_migration"
+version = "0.0.0"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+near-plugins = { path = "../../../../near-plugins" }
+near-sdk = "4.1.0"
+
+[profile.release]
+codegen-units = 1
+opt-level = "z"
+lto = true
+debug = false
+panic = "abort"
+overflow-checks = true
+
+[workspace]

--- a/near-plugins-derive/tests/contracts/upgradable_state_migration/Makefile
+++ b/near-plugins-derive/tests/contracts/upgradable_state_migration/Makefile
@@ -1,0 +1,8 @@
+build:
+	cargo build --target wasm32-unknown-unknown --release
+
+# Helpful for debugging. Requires `cargo-expand`.
+expand:
+	cargo expand > expanded.rs
+
+.PHONY: build expand

--- a/near-plugins-derive/tests/contracts/upgradable_state_migration/rust-toolchain
+++ b/near-plugins-derive/tests/contracts/upgradable_state_migration/rust-toolchain
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.66.1"
+components = ["clippy", "rustfmt"]

--- a/near-plugins-derive/tests/contracts/upgradable_state_migration/src/lib.rs
+++ b/near-plugins-derive/tests/contracts/upgradable_state_migration/src/lib.rs
@@ -1,0 +1,72 @@
+//! A simple contract to be deployed via `Upgradable`. It requires [state migration].
+//!
+//! [state migration]: https://docs.near.org/develop/upgrade#migrating-the-state
+
+use near_plugins::{access_control, AccessControlRole, AccessControllable, Upgradable};
+use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
+use near_sdk::serde::{Deserialize, Serialize};
+use near_sdk::{env, near_bindgen, PanicOnDefault};
+
+/// Roles correspond to those defined in the initial contract `../upgradable`, to make permissions
+/// granted before the upgrade remain valid.
+#[derive(AccessControlRole, Deserialize, Serialize, Copy, Clone)]
+#[serde(crate = "near_sdk::serde")]
+pub enum Role {
+    DAO,
+    CodeStager,
+    CodeDeployer,
+    DurationManager,
+}
+
+/// The struct differs from the one defined in the initial contract `../upgradable`, hence [state
+/// migration] is required.
+///
+/// [state migration]: https://docs.near.org/develop/upgrade#migrating-the-state
+#[access_control(role_type(Role))]
+#[near_bindgen]
+#[derive(Upgradable, PanicOnDefault, BorshDeserialize, BorshSerialize)]
+#[upgradable(access_control_roles(
+    code_stagers(Role::CodeStager, Role::DAO),
+    code_deployers(Role::CodeDeployer, Role::DAO),
+    duration_initializers(Role::DurationManager, Role::DAO),
+    duration_update_stagers(Role::DurationManager, Role::DAO),
+    duration_update_appliers(Role::DurationManager, Role::DAO),
+))]
+pub struct Contract {
+    is_migrated: bool,
+}
+
+#[near_bindgen]
+impl Contract {
+    /// Migrates state from [`OldContract`] to [`Contract`].
+    ///
+    /// It follows the state migration pattern described [here].
+    ///
+    /// [here]: https://docs.near.org/develop/upgrade#migrating-the-state
+    #[private]
+    #[init(ignore_state)]
+    pub fn migrate() -> Self {
+        // Ensure old state can be read and deserialized.
+        let _: OldContract = env::state_read().expect("Should be able to load old state");
+
+        Self { is_migrated: true }
+    }
+
+    /// A migration method that fails on purpose to test the rollback mechanism of
+    /// `Upgradable::up_deploy_code`.
+    #[private]
+    #[init(ignore_state)]
+    pub fn migrate_with_failure() -> Self {
+        env::panic_str("Failing migration on purpose");
+    }
+
+    /// This method is _not_ defined in the initial contract, so calling it successfully proves the
+    /// contract defined in this file was deployed and the old state was migrated.
+    pub fn is_migrated(&self) -> bool {
+        self.is_migrated
+    }
+}
+
+/// Corresponds to the state defined in the initial `../upgradable` contract.
+#[derive(BorshDeserialize)]
+pub struct OldContract;

--- a/near-plugins-derive/tests/upgradable.rs
+++ b/near-plugins-derive/tests/upgradable.rs
@@ -419,7 +419,7 @@ async fn test_deploy_code_without_delay() -> anyhow::Result<()> {
     setup.assert_staged_code(Some(code)).await;
 
     // Deploy staged code.
-    let res = setup.upgradable_contract.up_deploy_code(&dao).await?;
+    let res = setup.upgradable_contract.up_deploy_code(&dao, None).await?;
     assert_success_with_unit_return(res);
 
     Ok(())
@@ -447,7 +447,7 @@ async fn test_deploy_code_and_call_method() -> anyhow::Result<()> {
     setup.assert_staged_code(Some(code)).await;
 
     // Deploy staged code.
-    let res = setup.upgradable_contract.up_deploy_code(&dao).await?;
+    let res = setup.upgradable_contract.up_deploy_code(&dao, None).await?;
     assert_success_with_unit_return(res);
 
     // The newly deployed contract defines the function `is_upgraded`. Calling it successfully
@@ -483,7 +483,7 @@ async fn test_deploy_code_with_delay() -> anyhow::Result<()> {
     fast_forward_beyond(&worker, staging_duration).await;
 
     // Deploy staged code.
-    let res = setup.upgradable_contract.up_deploy_code(&dao).await?;
+    let res = setup.upgradable_contract.up_deploy_code(&dao, None).await?;
     assert_success_with_unit_return(res);
 
     Ok(())
@@ -513,7 +513,7 @@ async fn test_deploy_code_with_delay_failure_too_early() -> anyhow::Result<()> {
     fast_forward_beyond(&worker, sdk_duration_from_secs(1)).await;
 
     // Verify trying to deploy staged code fails.
-    let res = setup.upgradable_contract.up_deploy_code(&dao).await?;
+    let res = setup.upgradable_contract.up_deploy_code(&dao, None).await?;
     assert_failure_with(res, ERR_MSG_DEPLOY_CODE_TOO_EARLY);
 
     Ok(())
@@ -538,7 +538,7 @@ async fn test_deploy_code_permission_failure() -> anyhow::Result<()> {
     // call this method.
     let res = setup
         .upgradable_contract
-        .up_deploy_code(&setup.unauth_account)
+        .up_deploy_code(&setup.unauth_account, None)
         .await?;
     assert_insufficient_acl_permissions(
         res,
@@ -577,7 +577,7 @@ async fn test_deploy_code_empty_failure() -> anyhow::Result<()> {
     // The staging timestamp is set when staging code and removed when unstaging code. So when there
     // is no code staged, there is no staging timestamp. Hence the error message regarding a missing
     // staging timestamp is expected.
-    let res = setup.upgradable_contract.up_deploy_code(&dao).await?;
+    let res = setup.upgradable_contract.up_deploy_code(&dao, None).await?;
     assert_failure_with(res, ERR_MSG_NO_STAGING_TS);
 
     Ok(())
@@ -825,7 +825,7 @@ async fn test_acl_permission_scope() -> anyhow::Result<()> {
     // deploy code.
     let res = setup
         .upgradable_contract
-        .up_deploy_code(&setup.unauth_account)
+        .up_deploy_code(&setup.unauth_account, None)
         .await?;
     assert_insufficient_acl_permissions(
         res,

--- a/near-plugins/src/upgradable.rs
+++ b/near-plugins/src/upgradable.rs
@@ -57,7 +57,7 @@
 //! [time between scheduling and execution]: https://docs.near.org/sdk/rust/promises/intro
 use crate::events::{AsEvent, EventMetadata};
 use near_sdk::serde::{Deserialize, Serialize};
-use near_sdk::{AccountId, CryptoHash, Promise};
+use near_sdk::{AccountId, Balance, CryptoHash, Gas, Promise};
 
 /// Trait describing the functionality of the _Upgradable_ plugin.
 pub trait Upgradable {
@@ -103,7 +103,7 @@ pub trait Upgradable {
     /// specified via the `code_deployers` field of the `Upgradable` macro's `access_control_roles`
     /// attribute. The example contract (accessible via the `README`) shows how access control roles
     /// can be defined and passed on to the `Upgradable` macro.
-    fn up_deploy_code(&mut self) -> Promise;
+    fn up_deploy_code(&mut self, function_call_args: Option<FunctionCallArgs>) -> Promise;
 
     /// Initializes the duration of the delay for deploying the staged code. It defaults to zero if
     /// code is staged before the staging duration is initialized. Once the staging duration has
@@ -148,6 +148,15 @@ pub struct UpgradableDurationStatus {
     pub staging_timestamp: Option<near_sdk::Timestamp>,
     pub new_staging_duration: Option<near_sdk::Duration>,
     pub new_staging_duration_timestamp: Option<near_sdk::Timestamp>,
+}
+
+// TODO add docs
+#[derive(Deserialize, Serialize, Debug)]
+pub struct FunctionCallArgs {
+    pub function_name: String,
+    pub arguments: Vec<u8>,
+    pub amount: Balance,
+    pub gas: Gas,
 }
 
 /// Event emitted when the code is staged

--- a/near-plugins/src/upgradable.rs
+++ b/near-plugins/src/upgradable.rs
@@ -23,10 +23,13 @@
 //! method. The documentation of these methods and the [example contract] explain how to define and
 //! whitelist roles to manage authorization for the `Upgradable` plugin.
 //!
-//! There may be several reasons to protect `deploy_code`. For example if an upgrade requires
-//! migration or initialization. In that case, it is recommended to run a batched transaction where
-//! [`Upgradable::up_deploy_code`] is called first, and then a function that executes the migration
-//! or initialization.
+//! ## State migration
+//!
+//! Upgrading a contract might require [state migration]. The `Upgradable` plugin allows to attach a
+//! function call to code deployments. Using this mechanism, state migration can be carried out by
+//! calling a migration function. If the function fails, the deployment is rolled back and the
+//! initial code remains active. More detailed information is available in the documentation of
+//! [`Upgradable::up_deploy_code`].
 //!
 //! ## Stale staged code
 //!
@@ -53,6 +56,7 @@
 //! `near-plugins-derive` does not support it.
 //!
 //! [example contract]: ../../near-plugins-derive/tests/contracts/upgradable/src/lib.rs
+//! [state migration]: https://docs.near.org/develop/upgrade#migrating-the-state
 //! [batch transaction]: https://docs.near.org/concepts/basics/transactions/overview
 //! [time between scheduling and execution]: https://docs.near.org/sdk/rust/promises/intro
 use crate::events::{AsEvent, EventMetadata};
@@ -98,11 +102,24 @@ pub trait Upgradable {
 
     /// Allows an authorized account to deploy the staged code. It panics if no code is staged.
     ///
+    /// If `function_call_args` are provided, code is deployed in a batch promise that contains the
+    /// `DeployContractAction` followed by `FunctionCallAction`. In case the function call fails,
+    /// the deployment is rolled back and the initial code remains active. For this purpose,
+    /// batching the actions mentioned above is required due to the [asynchronous design] of NEAR.
+    ///
+    /// Attaching a function call can be useful, for example, if deploying the staged code requires
+    /// [state migration]. It can be achieved by calling a migration function defined in the new
+    /// version of the contract. A failure during state migration can leave the contract in a broken
+    /// state, which is avoided by the roleback mechanism described above.
+    ///
     /// In the default implementation, this method is protected by access control provided by the
     /// `AccessControllable` plugin. The roles which may successfully call this method are
     /// specified via the `code_deployers` field of the `Upgradable` macro's `access_control_roles`
     /// attribute. The example contract (accessible via the `README`) shows how access control roles
     /// can be defined and passed on to the `Upgradable` macro.
+    ///
+    /// [asynchronous design]: https://docs.near.org/concepts/basics/transactions/overview
+    /// [state migration]: https://docs.near.org/develop/upgrade#migrating-the-state
     fn up_deploy_code(&mut self, function_call_args: Option<FunctionCallArgs>) -> Promise;
 
     /// Initializes the duration of the delay for deploying the staged code. It defaults to zero if
@@ -150,12 +167,17 @@ pub struct UpgradableDurationStatus {
     pub new_staging_duration_timestamp: Option<near_sdk::Timestamp>,
 }
 
-// TODO add docs
+/// Specifies a function call to be appended to the actions of a promise via
+/// [`near_sdk::Promise::function_call`]).
 #[derive(Deserialize, Serialize, Debug)]
 pub struct FunctionCallArgs {
+    /// The name of the function to call.
     pub function_name: String,
+    /// The arguments to pass to the function.
     pub arguments: Vec<u8>,
+    /// The amount of tokens to transfer to the receiver.
     pub amount: Balance,
+    /// The gas limit for the function call.
     pub gas: Gas,
 }
 


### PR DESCRIPTION
Closes #76 and this [external issue](https://github.com/AuditoneCodebase/Aurora-audit-review/issues/27).

Adds an additional parameter to `Upgradable::up_deploy_code` that allows to optionally specify a function call to be batched with the code deployment. This might be a function that migrates state. If that function call fails, the deployment is rolled back and the old code remains active.

# Breaking change
This is a breaking change since it modifies the signature of `Upgradable::up_deploy_code`. Users that want to maintain the previous behavior (deployment without function call) can migrate in the following way:

```rust
// Previously:
up_deploy_code()

// Same behavior with the new API:
up_deploy_code(None)
```
