### PR TITLE
docs(Upgradable): code removal after deplyoment

### DIFF
--- a/near-plugins-derive/tests/upgradable.rs
+++ b/near-plugins-derive/tests/upgradable.rs
@@ -569,7 +569,7 @@ async fn test_deploy_code_with_migration_failure_rollback() -> anyhow::Result<()
 /// The pitfall is that a failure in the promise returned by 1 does _not_ make the transaction fail
 /// and 2 executes anyway.
 #[tokio::test]
-async fn test_deploy_code_with_batched_removal_pitfall() -> anyhow::Result<()> {
+async fn test_deploy_code_in_batch_transaction_pitfall() -> anyhow::Result<()> {
     let worker = workspaces::sandbox().await?;
     let dao = worker.dev_create_account().await?;
     let setup = Setup::new(worker.clone(), Some(dao.id().clone()), None).await?;

--- a/near-plugins/src/upgradable.rs
+++ b/near-plugins/src/upgradable.rs
@@ -33,8 +33,9 @@
 //!
 //! ## Stale staged code
 //!
-//! After the code is deployed, it should be removed from staging. This will prevent old code with a
-//! security vulnerability to be deployed.
+//! After the code is deployed, it should be removed from staging. This prevents deploying old code
+//! that might contain a security vulnerability and avoids the issues described in
+//! [`Self::up_deploy_code`].
 //!
 //! ## Upgrading code that contains a security vulnerability
 //!
@@ -124,6 +125,13 @@ pub trait Upgradable {
     /// Once staged code is no longer needed, it can be removed by passing the appropriate arguments
     /// to [`Self::up_stage_code`]. Removing staged code allows to [unstake tokens] that are storage
     /// staked.
+    ///
+    /// It is recommended to remove staged code as soon as possible to avoid deploying code and
+    /// executing an attached function call multiple times. Using batch transaction for this purpose
+    /// can be dangerous. Since `up_deploy_code` returns a promise, there can be unexpected outcomes
+    /// when it is combined in a batch transaction with another function call that removes code from
+    /// storage. This is demonstrated in the `Upgradable` test
+    /// `test_deploy_code_in_batch_transaction_pitfall`.
     ///
     /// # Permissions
     ///


### PR DESCRIPTION
Makes it more explicit how staged code can be removed after it was deployed. Mentions the benefit of freeing storage.

Related to [this issue](https://github.com/AuditoneCodebase/Aurora-audit-review/issues/9) and its comment.