### PR TITLE
feat(Pausable)!: make `pa_[un]pause` return `bool`

### DIFF
--- a/near-plugins-derive/tests/pausable.rs
+++ b/near-plugins-derive/tests/pausable.rs
@@ -6,7 +6,7 @@ use common::access_controllable_contract::AccessControllableContract;
 use common::pausable_contract::PausableContract;
 use common::utils::{
     assert_failure_with, assert_insufficient_acl_permissions, assert_method_is_paused,
-    assert_success_with_unit_return,
+    assert_success_with, assert_success_with_unit_return,
 };
 use near_sdk::serde_json::json;
 use std::collections::HashSet;
@@ -131,11 +131,11 @@ async fn test_setup() -> anyhow::Result<()> {
 #[tokio::test]
 async fn test_pause_feature() -> anyhow::Result<()> {
     let setup = Setup::new().await?;
-    setup
+    let res = setup
         .pausable_contract
         .pa_pause_feature(&setup.pause_manager, "increase_1")
-        .await?
-        .into_result()?;
+        .await?;
+    assert_success_with(res, true);
     let res = setup
         .call_counter_modifier(&setup.unauth_account, "increase_1")
         .await?;
@@ -147,11 +147,11 @@ async fn test_pause_feature() -> anyhow::Result<()> {
 #[tokio::test]
 async fn test_pause_feature_from_pause_manager() -> anyhow::Result<()> {
     let setup = Setup::new().await?;
-    setup
+    let res = setup
         .pausable_contract
         .pa_pause_feature(&setup.pause_manager, "increase_1")
-        .await?
-        .into_result()?;
+        .await?;
+    assert_success_with(res, true);
     let res = setup
         .call_counter_modifier(&setup.pause_manager, "increase_1")
         .await?;
@@ -236,11 +236,11 @@ async fn test_unpause_not_allowed_from_self() -> anyhow::Result<()> {
 #[tokio::test]
 async fn test_pause_with_all() -> anyhow::Result<()> {
     let setup = Setup::new().await?;
-    setup
+    let res = setup
         .pausable_contract
         .pa_pause_feature(&setup.pause_manager, "ALL")
-        .await?
-        .into_result()?;
+        .await?;
+    assert_success_with(res, true);
     let res = setup
         .call_counter_modifier(&setup.unauth_account, "increase_1")
         .await?;
@@ -252,11 +252,11 @@ async fn test_pause_with_all() -> anyhow::Result<()> {
 #[tokio::test]
 async fn test_pause_with_all_allows_except() -> anyhow::Result<()> {
     let setup = Setup::new().await?;
-    setup
+    let res = setup
         .pausable_contract
         .pa_pause_feature(&setup.pause_manager, "ALL")
-        .await?
-        .into_result()?;
+        .await?;
+    assert_success_with(res, true);
 
     let exempted_account = setup.unauth_account.clone();
     setup
@@ -274,11 +274,11 @@ async fn test_pause_with_all_allows_except() -> anyhow::Result<()> {
 #[tokio::test]
 async fn test_not_paused_with_different_key() -> anyhow::Result<()> {
     let setup = Setup::new().await?;
-    setup
+    let res = setup
         .pausable_contract
         .pa_pause_feature(&setup.pause_manager, "other_feature")
-        .await?
-        .into_result()?;
+        .await?;
+    assert_success_with(res, true);
 
     let res = setup
         .call_counter_modifier(&setup.unauth_account, "increase_1")
@@ -294,22 +294,22 @@ async fn test_work_after_unpause() -> anyhow::Result<()> {
     let setup = Setup::new().await?;
 
     // After pausing function call fails.
-    setup
+    let res = setup
         .pausable_contract
         .pa_pause_feature(&setup.pause_manager, "increase_1")
-        .await?
-        .into_result()?;
+        .await?;
+    assert_success_with(res, true);
     let res = setup
         .call_counter_modifier(&setup.unauth_account, "increase_1")
         .await?;
     assert_method_is_paused(res);
 
     // After unpausing function call succeeds.
-    setup
+    let res = setup
         .pausable_contract
         .pa_unpause_feature(&setup.pause_manager, "increase_1")
-        .await?
-        .into_result()?;
+        .await?;
+    assert_success_with(res, true);
     let res = setup
         .call_counter_modifier(&setup.unauth_account, "increase_1")
         .await?;
@@ -334,11 +334,11 @@ async fn test_paused_list() -> anyhow::Result<()> {
 
     assert_paused_list(None, &setup.pausable_contract, &setup.unauth_account).await;
 
-    setup
+    let res = setup
         .pausable_contract
         .pa_pause_feature(&setup.pause_manager, "feature_a")
-        .await?
-        .into_result()?;
+        .await?;
+    assert_success_with(res, true);
     assert_paused_list(
         Some(HashSet::from(["feature_a".to_string()])),
         &setup.pausable_contract,
@@ -346,11 +346,11 @@ async fn test_paused_list() -> anyhow::Result<()> {
     )
     .await;
 
-    setup
+    let res = setup
         .pausable_contract
         .pa_pause_feature(&setup.pause_manager, "feature_b")
-        .await?
-        .into_result()?;
+        .await?;
+    assert_success_with(res, true);
     assert_paused_list(
         Some(HashSet::from([
             "feature_a".to_string(),
@@ -361,11 +361,11 @@ async fn test_paused_list() -> anyhow::Result<()> {
     )
     .await;
 
-    setup
+    let res = setup
         .pausable_contract
         .pa_unpause_feature(&setup.pause_manager, "feature_a")
-        .await?
-        .into_result()?;
+        .await?;
+    assert_success_with(res, true);
     assert_paused_list(
         Some(HashSet::from(["feature_b".to_string()])),
         &setup.pausable_contract,
@@ -393,11 +393,11 @@ async fn test_is_paused() -> anyhow::Result<()> {
     )
     .await;
 
-    setup
+    let res = setup
         .pausable_contract
         .pa_pause_feature(&setup.pause_manager, "feature_a")
-        .await?
-        .into_result()?;
+        .await?;
+    assert_success_with(res, true);
     assert_is_paused(
         true,
         "feature_a",
@@ -406,11 +406,11 @@ async fn test_is_paused() -> anyhow::Result<()> {
     )
     .await;
 
-    setup
+    let res = setup
         .pausable_contract
         .pa_unpause_feature(&setup.pause_manager, "feature_a")
-        .await?
-        .into_result()?;
+        .await?;
+    assert_success_with(res, true);
     assert_is_paused(
         false,
         "feature_a",
@@ -427,11 +427,11 @@ async fn test_is_paused() -> anyhow::Result<()> {
 async fn test_pause_custom_name_ok() -> anyhow::Result<()> {
     let setup = Setup::new().await?;
 
-    setup
+    let res = setup
         .pausable_contract
         .pa_pause_feature(&setup.pause_manager, "increase_2")
-        .await?
-        .into_result()?;
+        .await?;
+    assert_success_with(res, true);
 
     let res = setup
         .call_counter_modifier(&setup.unauth_account, "increase_2")
@@ -446,11 +446,11 @@ async fn test_pause_custom_name_ok() -> anyhow::Result<()> {
 async fn test_pause_custom_name_fail() -> anyhow::Result<()> {
     let setup = Setup::new().await?;
 
-    setup
+    let res = setup
         .pausable_contract
         .pa_pause_feature(&setup.pause_manager, "Increase by two")
-        .await?
-        .into_result()?;
+        .await?;
+    assert_success_with(res, true);
 
     let res = setup
         .call_counter_modifier(&setup.unauth_account, "increase_2")
@@ -465,11 +465,11 @@ async fn test_pause_except_ok() -> anyhow::Result<()> {
     let setup = Setup::new().await?;
 
     // Pause feature.
-    setup
+    let res = setup
         .pausable_contract
         .pa_pause_feature(&setup.pause_manager, "increase_4")
-        .await?
-        .into_result()?;
+        .await?;
+    assert_success_with(res, true);
 
     // Grantee of `Role::Unrestricted4Increaser` is exempted.
     let increaser = setup.worker.dev_create_account().await?;
@@ -501,11 +501,11 @@ async fn test_pause_except_fail() -> anyhow::Result<()> {
     let setup = Setup::new().await?;
 
     // Pause feature.
-    setup
+    let res = setup
         .pausable_contract
         .pa_pause_feature(&setup.pause_manager, "increase_4")
-        .await?
-        .into_result()?;
+        .await?;
+    assert_success_with(res, true);
 
     // Calling the method from an account which is not exempted fails.
     let res = setup
@@ -534,11 +534,11 @@ async fn test_custom_big_fail() -> anyhow::Result<()> {
     let setup = Setup::new().await?;
 
     // Pause feature.
-    setup
+    let res = setup
         .pausable_contract
         .pa_pause_feature(&setup.pause_manager, "increase_big")
-        .await?
-        .into_result()?;
+        .await?;
+    assert_success_with(res, true);
 
     // Counter can still be increased until threshold.
     for _ in 0..3 {
@@ -570,11 +570,11 @@ async fn test_escape_hatch_ok() -> anyhow::Result<()> {
     assert_eq!(setup.get_counter().await?, 1);
 
     // Pause feature.
-    setup
+    let res = setup
         .pausable_contract
         .pa_pause_feature(&setup.pause_manager, "increase_1")
-        .await?
-        .into_result()?;
+        .await?;
+    assert_success_with(res, true);
 
     // Calling escape hatch succeeds.
     let res = setup

--- a/near-plugins/src/pausable.rs
+++ b/near-plugins/src/pausable.rs
@@ -51,7 +51,12 @@ pub trait Pausable {
     /// Pauses feature `key`. This method fails if the caller has not been granted one of the access
     /// control `manager_roles` passed to the `Pausable` plugin.
     ///
-    /// If the method succeeds, the following event will be emitted:
+    /// It returns `true` if the feature is paused as a result of this function call and `false` if
+    /// the feature was already paused. In either case, the feature is paused after the function
+    /// returns successfully.
+    ///
+    /// If the feature is newly paused (the return value is `true`), the following event will be
+    /// emitted:
     ///
     /// ```json
     /// {
@@ -65,12 +70,16 @@ pub trait Pausable {
     ///     }
     /// }
     /// ```
-    fn pa_pause_feature(&mut self, key: String);
+    fn pa_pause_feature(&mut self, key: String) -> bool;
 
     /// Unpauses feature `key`. This method fails if the caller has not been granted one of the
     /// access control `manager_roles` passed to the `Pausable` plugin.
     ///
-    /// If the method succeeds, the following event will be emitted:
+    /// It returns whether the feature was paused, i.e. `true` if the feature was paused and
+    /// otherwise `false`. In either case, the feature is unpaused after the function returns
+    /// successfully.
+    ///
+    /// If the feature was paused (the return value is `true`), the following event will be emitted:
     ///
     /// ```json
     /// {
@@ -84,7 +93,7 @@ pub trait Pausable {
     ///    }
     /// }
     /// ```
-    fn pa_unpause_feature(&mut self, key: String);
+    fn pa_unpause_feature(&mut self, key: String) -> bool;
 }
 
 /// Event emitted when a feature is paused.


### PR DESCRIPTION
Makes `pa_pause` and `pa_unpause` return a `bool` that indicates whether the feature is newly (un)paused. This corresponds to the return values of `std::collections::HashSet` methods [insert](https://doc.rust-lang.org/std/collections/struct.HashSet.html#method.insert) and [remove](https://doc.rust-lang.org/std/collections/struct.HashSet.html#method.remove).

Closes this [external issue](https://github.com/AuditoneCodebase/Aurora-audit-review/issues/32).

# Other changes: events
This PR also changes event emitting behavior. Sneaking it into this PR since it only reorders code in the two functions that are modified here.

Previously events `Pause` and `Unpause` were emitted even if:

- State was not modified since the feature was alreay (un)paused.
- The function panicked because state could not be serialized.

To avoid this, code that emits events has been moved past actions that may fail.

# Breaking changes
- `pa_pause` and `pa_unpause` return `bool` (previously no return value).
- `Pause` and `Unpause` events are only emitted when state is successfully modified.