### PR TITLE
chore: use `emit` to log events

### DIFF
--- a/near-plugins-derive/src/ownable.rs
+++ b/near-plugins-derive/src/ownable.rs
@@ -57,12 +57,11 @@ pub fn derive_ownable(input: TokenStream) -> TokenStream {
                     );
                 }
 
-                ::near_sdk::log!(#cratename::events::AsEvent::event(
-                    &#cratename::ownable::OwnershipTransferred {
-                        previous_owner: current_owner,
-                        new_owner: owner.clone()
-                    }
-                ));
+                let event = #cratename::ownable::OwnershipTransferred {
+                    previous_owner: current_owner,
+                    new_owner: owner.clone(),
+                };
+                #cratename::events::AsEvent::emit(&event);
 
                 match owner.as_ref() {
                     Some(owner) => ::near_sdk::env::storage_write(

--- a/near-plugins-derive/src/pausable.rs
+++ b/near-plugins-derive/src/pausable.rs
@@ -71,12 +71,11 @@ pub fn derive_pausable(input: TokenStream) -> TokenStream {
                         .as_ref(),
                 );
 
-                ::near_sdk::log!(#cratename::events::AsEvent::event(
-                    &#cratename::pausable::Pause {
-                        by: ::near_sdk::env::predecessor_account_id(),
-                        key,
-                    }
-                ));
+                let event = #cratename::pausable::Pause {
+                    by: ::near_sdk::env::predecessor_account_id(),
+                    key,
+                };
+                #cratename::events::AsEvent::emit(&event);
 
                 // The feature is newly paused.
                 true
@@ -104,12 +103,11 @@ pub fn derive_pausable(input: TokenStream) -> TokenStream {
                     );
                 }
 
-                ::near_sdk::log!(#cratename::events::AsEvent::event(
-                    &#cratename::pausable::Unpause {
-                        by: ::near_sdk::env::predecessor_account_id(),
-                        key,
-                    }
-                ));
+                let event = #cratename::pausable::Unpause {
+                    by: ::near_sdk::env::predecessor_account_id(),
+                    key,
+                };
+                #cratename::events::AsEvent::emit(&event);
 
                 // The feature was paused.
                 true


### PR DESCRIPTION
Use the `emit` method to cleanup code and avoid duplicating logging logic.