### PR TITLE
docs(Upgradable): remove confusing statement

### DIFF
--- a/near-plugins/src/upgradable.rs
+++ b/near-plugins/src/upgradable.rs
@@ -33,9 +33,8 @@
 //!
 //! ## Stale staged code
 //!
-//! After the code is deployed, it should be removed from staging. This prevents deploying old code
-//! that might contain a security vulnerability and avoids the issues described in
-//! [`Self::up_deploy_code`].
+//! After the code is deployed, it should be removed from staging to unstake tokens and avoid the
+//! issues described in [`Self::up_deploy_code`].
 //!
 //! ## Upgrading code that contains a security vulnerability
 //!


### PR DESCRIPTION
Using the `Upgradable` plugin makes sense when there are no other ways to deploy code. Under that assumption stale staged code is equal to deployed code and the statement removed in this PR is confusing.

With this change the section `# Stale staged code` in the module documentation becomes very short. Still I think it makes sense to keep it there, to highlight the importance of handling stale staged code.