### PR TITLE
feat(Acl): add `acl_add_super_admin`

### DIFF
--- a/near-plugins-derive/src/access_controllable.rs
+++ b/near-plugins-derive/src/access_controllable.rs
@@ -151,6 +151,13 @@ pub fn access_controllable(attrs: TokenStream, item: TokenStream) -> TokenStream
                 res
             }
 
+            fn add_super_admin(&mut self, account_id: &::near_sdk::AccountId) -> Option<bool> {
+                if !self.is_super_admin(&::near_sdk::env::predecessor_account_id()) {
+                    return None;
+                }
+                Some(self.add_super_admin_unchecked(account_id))
+            }
+
             /// Makes `account_id` a super-admin __without__ checking any permissions.
             /// It returns whether `account_id` is a new super-admin.
             ///
@@ -561,6 +568,10 @@ pub fn access_controllable(attrs: TokenStream, item: TokenStream) -> TokenStream
             #[private]
             fn acl_init_super_admin(&mut self, account_id: ::near_sdk::AccountId) -> bool {
                 self.acl_get_or_init().init_super_admin(&account_id)
+            }
+
+            fn acl_add_super_admin(&mut self, account_id: ::near_sdk::AccountId) -> Option<bool> {
+                self.acl_get_or_init().add_super_admin(&account_id)
             }
 
             fn acl_role_variants(&self) -> Vec<&'static str> {

--- a/near-plugins-derive/tests/common/access_controllable_contract.rs
+++ b/near-plugins-derive/tests/common/access_controllable_contract.rs
@@ -67,6 +67,24 @@ impl AccessControllableContract {
             .await
     }
 
+    pub async fn acl_add_super_admin(
+        &self,
+        caller: &Account,
+        account_id: &AccountId,
+    ) -> anyhow::Result<Option<bool>> {
+        let res = caller
+            .call(self.contract.id(), "acl_add_super_admin")
+            .args_json(json!({
+                "account_id": account_id,
+            }))
+            .max_gas()
+            .transact()
+            .await?
+            .into_result()?
+            .json::<Option<bool>>()?;
+        Ok(res)
+    }
+
     pub async fn acl_add_super_admin_unchecked(
         &self,
         caller: &Account,

--- a/near-plugins/src/access_controllable.rs
+++ b/near-plugins/src/access_controllable.rs
@@ -58,6 +58,9 @@ pub trait AccessControllable {
     /// It is `#[private]` in the implementation provided by this trait, i.e.
     /// only the contract itself may call this method.
     ///
+    /// Despite the restrictions of this method, it is possible to add multiple
+    /// super-admins using [`acl_add_super_admin`].
+    ///
     /// If a super-admin is added, the following event will be emitted:
     ///
     /// ```json
@@ -71,12 +74,32 @@ pub trait AccessControllable {
     ///    }
     /// }
     /// ```
-    ///
-    /// Despite the restrictions of this method, there might be multiple
-    /// super-admins. Adding more than one admin requires the use of internal
-    /// methods. The default implementation of `AccessControllable` provided by
-    /// this trait offers `add_super_admin_unchecked.`
     fn acl_init_super_admin(&mut self, account_id: AccountId) -> bool;
+
+    /// Adds `account_id` as super-admin provided that the predecessor has sufficient permissions,
+    /// i.e. is a super-admin as defined by [`acl_is_super_admin`]. To add the first super-admin,
+    /// [`acl_init_super_admin`] can be used.
+    ///
+    /// In case of sufficient permissions, the returned `Some(bool)` indicates whether `account_id`
+    /// is a new super-admin. Without permissions, `None` is returned and internal state is not
+    /// modified.
+    ///
+    /// Note that there may be multiple (or zero) super-admins.
+    ///
+    /// If a super-admin is added, the following event will be emitted:
+    ///
+    /// ```json
+    /// {
+    ///    "standard":"AccessControllable",
+    ///    "version":"1.0.0",
+    ///    "event":"super_admin_added",
+    ///    "data":{
+    ///       "account":"<NEW_SUPER_ADMIN>",
+    ///       "by":"<SUPER_ADMIN>"
+    ///    }
+    /// }
+    /// ```
+    fn acl_add_super_admin(&mut self, account_id: AccountId) -> Option<bool>;
 
     /// Returns whether `account_id` is a super-admin. A super-admin has admin
     /// permissions for every role. However, a super-admin is not considered


### PR DESCRIPTION
Adds the function to the `AccessControllable` trait and provides a default implementation.

Previously super-admins could be added only via `acl_init_super_admin` and `add_super_admin_unchecked`, which is an internal function of the default implementation.

`acl_add_super_admin` allows adding multiple super-admins without having to use internal functions.