### PR TITLE
test(Ownable): removing contract keys freezes owner

### DIFF
--- a/near-plugins-derive/tests/common/key.rs
+++ b/near-plugins-derive/tests/common/key.rs
@@ -1,0 +1,20 @@
+use workspaces::result::ExecutionFinalResult;
+use workspaces::types::{AccessKeyInfo, PublicKey};
+use workspaces::{Account, AccountId, Contract};
+
+/// Creates a transaction signed by `signer` to delete `key` from `contract`.
+pub async fn delete_access_key(
+    signer: &Account,
+    contract: &AccountId,
+    key: PublicKey,
+) -> workspaces::Result<ExecutionFinalResult> {
+    signer.batch(contract).delete_key(key).transact().await
+}
+
+/// Panics if access key info cannot be retrieved.
+pub async fn get_access_key_infos(contract: &Contract) -> Vec<AccessKeyInfo> {
+    contract
+        .view_access_keys()
+        .await
+        .expect("Should retrieve access keys")
+}

--- a/near-plugins-derive/tests/common/mod.rs
+++ b/near-plugins-derive/tests/common/mod.rs
@@ -1,4 +1,5 @@
 pub mod access_controllable_contract;
+pub mod key;
 pub mod ownable_contract;
 pub mod pausable_contract;
 pub mod repo;

--- a/near-plugins-derive/tests/common/utils.rs
+++ b/near-plugins-derive/tests/common/utils.rs
@@ -171,6 +171,26 @@ pub fn assert_failure_with(res: ExecutionFinalResult, must_contain: &str) {
     );
 }
 
+pub fn assert_access_key_not_found_error(
+    res: workspaces::Result<ExecutionFinalResult, workspaces::error::Error>,
+) {
+    let err = res
+        .err()
+        .expect("Transaction should not have been executed");
+
+    // Debug formatting is required to get the full error message containing `AccessKeyNotFound`.
+    // Assume that is acceptable since this function is avaible only in tests.
+    let err = format!("{:?}", err);
+    let must_contain = "InvalidAccessKeyError";
+
+    assert!(
+        err.contains(must_contain),
+        "The expected message\n'{}'\nis not contained in error\n'{}'",
+        must_contain,
+        err,
+    );
+}
+
 /// Returns the block timestamp in nanoseconds. Panics on failure.
 async fn block_timestamp(worker: &Worker<Sandbox>) -> u64 {
     worker

--- a/near-plugins-derive/tests/common/utils.rs
+++ b/near-plugins-derive/tests/common/utils.rs
@@ -174,9 +174,7 @@ pub fn assert_failure_with(res: ExecutionFinalResult, must_contain: &str) {
 pub fn assert_access_key_not_found_error(
     res: workspaces::Result<ExecutionFinalResult, workspaces::error::Error>,
 ) {
-    let err = res
-        .err()
-        .expect("Transaction should not have been executed");
+    let err = res.expect_err("Transaction should not have been executed");
 
     // Debug formatting is required to get the full error message containing `AccessKeyNotFound`.
     // Assume that is acceptable since this function is avaible only in tests.


### PR DESCRIPTION
Adds a test to verify that that the account of an `Ownable` contract cannot set a new owner after its access keys are removed.