### PR TITLE
refactor(Acl): reorder state modifications

### DIFF
--- a/near-plugins-derive/src/access_controllable.rs
+++ b/near-plugins-derive/src/access_controllable.rs
@@ -207,8 +207,17 @@ pub fn access_controllable(attrs: TokenStream, item: TokenStream) -> TokenStream
                     return None;
                 }
 
+                // The following state modifications can be considered atomic: They happen in the
+                // current `FunctionCall` action because no promises or cross contract calls are
+                // scheduled.
+                //
+                // If this ever changes, it should be avoided that revoking `current_super_admin`
+                // succeeds and adding `account_id` as super-admin fails. This could lock contracts
+                // in a state without super-admins. To protect against this scenario, the new
+                // super-admin is added first.
+                let is_new_super_admin = self.add_super_admin_unchecked(&account_id);
                 self.revoke_super_admin_unchecked(&current_super_admin);
-                Some(self.add_super_admin_unchecked(&account_id))
+                Some(is_new_super_admin)
             }
 
             /// Revokes super-admin permissions from `account_id` without checking any


### PR DESCRIPTION
Reorders the state modifications in `acl_transfer_super_admin` as suggested in [this comment](https://github.com/aurora-is-near/near-plugins/pull/94#discussion_r1137435879).