### PR TITLE
build: only use `borsh` re-exported by `near-sdk`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ near-plugins = { path = "near-plugins" }
 near-plugins-derive = { path = "near-plugins-derive" }
 serde = "1"
 anyhow = "1.0"
-borsh = "0.9"
 tokio = { version = "1", features = ["full"] }
 near-workspaces = "0.9"
 toml = "0.5"

--- a/near-plugins-derive/Cargo.toml
+++ b/near-plugins-derive/Cargo.toml
@@ -17,7 +17,6 @@ proc-macro-crate.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true
-borsh.workspace = true
 near-plugins.workspace = true
 near-sdk.workspace = true
 tokio.workspace = true

--- a/scripts/fix_dependencies.sh
+++ b/scripts/fix_dependencies.sh
@@ -13,5 +13,5 @@
 # for some other attempts and how they failed in CI).
 cargo update -p anstyle@1.0.4 --precise 1.0.2
 cargo update -p anstyle-parse@0.2.2 --precise 0.2.1
-cargo update -p clap@4.4.7 --precise 4.3.24
+cargo update -p clap@4.4.8 --precise 4.3.24
 cargo update -p clap_lex@0.5.1 --precise 0.5.0


### PR DESCRIPTION
`near-plugins-derive` was the only workspace member that depended on `borsh`. However, it isn’t actually used. Instead `borsh` re-exported by `near-sdk` is used, which is considered [best practice](https://docs.near.org/sdk/rust/best-practices#reuse-crates-from-near-sdk). Removing the `borsh` dependency might also prevent using it accidentally (instead of `borsh` re-exported by `near-sdk`) in the future.