### PR TITLE
Prepare release of v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 0.2.0 (TBD)
+
+## BREAKING CHANGES:
+
+- #118: Update of `rust-version` (MSRV) from 1.64.0 to 1.69.0. Contracts using `near-plugins` now require a Rust version of at least 1.69.0.
+  - Developers who want to run the test suite of `near-plugins` and run into compilation errors can follow [this workaround](https://github.com/aurora-is-near/near-plugins/pull/118#issuecomment-1794576809).
+
+## Dependencies
+
+### Dev-dependencies
+
+- #118 upgrades:
+  - `near-sdk`
+  - `near-workspaces`
+- #122 removes `borsh` which was an unused dev-dependencies.
+
 # 0.1.0 (2023-05-08)
 
 This section lists changes affecting multiple plugins. Changes that affect only individual plugins are listed below.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,17 @@
 
 ## BREAKING CHANGES:
 
-- #118: Update of `rust-version` (MSRV) from 1.64.0 to 1.69.0. Contracts using `near-plugins` now require a Rust version of at least 1.69.0.
+- [#118](https://github.com/aurora-is-near/near-plugins/pull/118): Update of `rust-version` (MSRV) from 1.64.0 to 1.69.0. Contracts using `near-plugins` now require a Rust version of at least 1.69.0.
   - Developers who want to run the test suite of `near-plugins` and run into compilation errors can follow [this workaround](https://github.com/aurora-is-near/near-plugins/pull/118#issuecomment-1794576809).
 
 ## Dependencies
 
 ### Dev-dependencies
 
-- #118 upgrades:
+- [#118](https://github.com/aurora-is-near/near-plugins/pull/118) upgrades:
   - `near-sdk`
   - `near-workspaces`
-- #122 removes `borsh` which was an unused dev-dependencies.
+- [#122](https://github.com/aurora-is-near/near-plugins/pull/122) removes `borsh` which was an unused dev-dependencies.
 
 # 0.1.0 (2023-05-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - [#118](https://github.com/aurora-is-near/near-plugins/pull/118): Update of `rust-version` (MSRV) from 1.64.0 to 1.69.0. Contracts using `near-plugins` now require a Rust version of at least 1.69.0.
   - Developers who want to run the test suite of `near-plugins` and run into compilation errors can follow [this workaround](https://github.com/aurora-is-near/near-plugins/pull/118#issuecomment-1794576809).
 
+## Testing
+
+- [128](https://github.com/aurora-is-near/near-plugins/pull/128) applies temporary workarounds required to build tests.
+
 ## Dependencies
 
 ### Dev-dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ exclude = ["target", "examples"]
 version = "0.15.0"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Aurora Labs <hello@aurora.dev>"]
 rust-version = "1.69.0"


### PR DESCRIPTION
Motivation for doing a new release:

- Tests might not be built for the current release ([ref](https://github.com/aurora-is-near/near-plugins/pull/118)).
- An [article](https://github.com/mooori/counter-acl-example/pull/1) on `near-plugins` is planned to be published soon and it would be good to release recent changes before that.