### PR TITLE
build: add workarounds required to build tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,8 @@ proc-macro2 = "1.0"
 quote = "1.0.9"
 syn = { version = "1.0.69", features = ["full"] }
 proc-macro-crate = "0.1.5"
+
+# Required to build tests with near-sdk v4.1.1, see #128.
+# TODO(#125): Remove after upgrading to near-sdk v5.
+[patch.crates-io]
+parity-secp256k1 = {git = "https://github.com/paritytech/rust-secp256k1", tag = "parity-secp256k1-v0.7.0"}

--- a/near-plugins-derive/tests/contracts/access_controllable/Cargo.toml
+++ b/near-plugins-derive/tests/contracts/access_controllable/Cargo.toml
@@ -19,3 +19,8 @@ panic = "abort"
 overflow-checks = true
 
 [workspace]
+
+# Required to build tests with near-sdk v4.1.1, see #128.
+# TODO(#125): Remove after upgrading to near-sdk v5.
+[patch.crates-io]
+parity-secp256k1 = {git = "https://github.com/paritytech/rust-secp256k1", tag = "parity-secp256k1-v0.7.0"}

--- a/near-plugins-derive/tests/contracts/ownable/Cargo.toml
+++ b/near-plugins-derive/tests/contracts/ownable/Cargo.toml
@@ -19,3 +19,8 @@ panic = "abort"
 overflow-checks = true
 
 [workspace]
+
+# Required to build tests with near-sdk v4.1.1, see #128.
+# TODO(#125): Remove after upgrading to near-sdk v5.
+[patch.crates-io]
+parity-secp256k1 = {git = "https://github.com/paritytech/rust-secp256k1", tag = "parity-secp256k1-v0.7.0"}

--- a/near-plugins-derive/tests/contracts/pausable/Cargo.toml
+++ b/near-plugins-derive/tests/contracts/pausable/Cargo.toml
@@ -19,3 +19,8 @@ panic = "abort"
 overflow-checks = true
 
 [workspace]
+
+# Required to build tests with near-sdk v4.1.1, see #128.
+# TODO(#125): Remove after upgrading to near-sdk v5.
+[patch.crates-io]
+parity-secp256k1 = {git = "https://github.com/paritytech/rust-secp256k1", tag = "parity-secp256k1-v0.7.0"}

--- a/near-plugins-derive/tests/contracts/upgradable/Cargo.toml
+++ b/near-plugins-derive/tests/contracts/upgradable/Cargo.toml
@@ -19,3 +19,8 @@ panic = "abort"
 overflow-checks = true
 
 [workspace]
+
+# Required to build tests with near-sdk v4.1.1, see #128.
+# TODO(#125): Remove after upgrading to near-sdk v5.
+[patch.crates-io]
+parity-secp256k1 = {git = "https://github.com/paritytech/rust-secp256k1", tag = "parity-secp256k1-v0.7.0"}

--- a/near-plugins-derive/tests/contracts/upgradable_2/Cargo.toml
+++ b/near-plugins-derive/tests/contracts/upgradable_2/Cargo.toml
@@ -19,3 +19,8 @@ panic = "abort"
 overflow-checks = true
 
 [workspace]
+
+# Required to build tests with near-sdk v4.1.1, see #128.
+# TODO(#125): Remove after upgrading to near-sdk v5.
+[patch.crates-io]
+parity-secp256k1 = {git = "https://github.com/paritytech/rust-secp256k1", tag = "parity-secp256k1-v0.7.0"}

--- a/near-plugins-derive/tests/contracts/upgradable_state_migration/Cargo.toml
+++ b/near-plugins-derive/tests/contracts/upgradable_state_migration/Cargo.toml
@@ -19,3 +19,8 @@ panic = "abort"
 overflow-checks = true
 
 [workspace]
+
+# Required to build tests with near-sdk v4.1.1, see #128.
+# TODO(#125): Remove after upgrading to near-sdk v5.
+[patch.crates-io]
+parity-secp256k1 = {git = "https://github.com/paritytech/rust-secp256k1", tag = "parity-secp256k1-v0.7.0"}

--- a/scripts/fix_dependencies.sh
+++ b/scripts/fix_dependencies.sh
@@ -11,7 +11,12 @@
 # version of `clap` is released, say 4.4.8, then below must be changed to `-p clap@4.4.8`. Even
 # though this requires maintenance, it seems to be cleanest approach that works with CI (see #119
 # for some other attempts and how they failed in CI).
+cargo update -p ahash@0.8.7 --precise 0.8.4
 cargo update -p anstyle@1.0.4 --precise 1.0.2
-cargo update -p anstyle-parse@0.2.2 --precise 0.2.1
-cargo update -p clap@4.4.8 --precise 4.3.24
+cargo update -p anstyle-parse@0.2.3 --precise 0.2.1
+cargo update -p anstyle-query@1.0.2 --precise 1.0.0
+cargo update -p cargo-platform@0.1.6 --precise 0.1.5
+cargo update -p clap@4.4.18 --precise 4.3.24
 cargo update -p clap_lex@0.5.1 --precise 0.5.0
+cargo update -p colored@2.1.0 --precise 2.0.4
+cargo update -p home@0.5.9 --precise 0.5.5


### PR DESCRIPTION
## Override `parity-secp256k1`

Building tests may currently fail since a dependency of `near-sdk` v4.1.1 (most recent release) has been yanked. Providing a patch is the [recommended workaround](https://github.com/near/near-sdk-rs/issues/1119#issuecomment-1889323112).

A new version of `near-sdk` is planned to be released soon. Then this patch shouldn’t be required anymore ([ref.](https://github.com/near/near-sdk-rs/issues/1119#issuecomment-1889323112)). 

## Update `scripts/fix-dependencies`

By now more recursive dependencies need to be downgraded manually for tests to build with MSRV 1.69.0. See [this comment](https://github.com/aurora-is-near/near-plugins/pull/118#issuecomment-1794576809) for details.