### PR TITLE
build: stop pinning a toolchain version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.69.0 # MSRV
+          target: wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.69.0 # MSRV
+          override: true
           target: wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@v1
@@ -44,6 +45,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.69.0 # MSRV
+          override: true
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
         with:
-          key: rust-version-1.69.0-msrv
+          key: rust-version-1.69.0-msrv-2
 
       - name: downgrade some dev-dependencies for msrv, see https://github.com/near/near-workspaces-rs/issues/336
         run: ./scripts/fix_dependencies.sh
@@ -47,7 +47,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
         with:
-          key: rust-version-1.69.0-msrv
+          key: rust-version-1.69.0-msrv-2
 
       - name: downgrade some dev-dependencies for msrv, see https://github.com/near/near-workspaces-rs/issues/336
         run: ./scripts/fix_dependencies.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.69.0 # MSRV
 
       - uses: Swatinem/rust-cache@v1
         with:
@@ -42,7 +42,7 @@ jobs:
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.69.0 # MSRV
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ version = "0.15.0"
 version = "0.2.0"
 edition = "2021"
 authors = ["Aurora Labs <hello@aurora.dev>"]
+# An update of the MSRV requires updating:
+# - `rust-toolchain` files in `near-plugins-derive/tests/contracts/**`
+# - the toolchain installed in CI via the `toolchain` parameter of `actions-rs/toolchain@v1`
 rust-version = "1.69.0"
 description = "Ergonomic plugin system to extend NEAR contracts."
 license = "CC0-1.0"

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ automatically from macros. They can be changed if the trait is manually implemen
 
 ## Contributor Notes
 
+[Contracts used in tests](/near-plugins-derive/tests/contracts/) set `channel = <MSRV>` in their `rust-toolchain` to make tests ensure that plugins are compatible with the MSRV. Developers working on this repo might want to locally set `channel = <MSRV>` in the root `./rust-toolchain` to surface incompabilities with the MSRV early on.
+
+Why not commit `channel = <MSRV>` to `./rust-toolchain`? As a library crate we should leave the choice of the channel to users. Moreover, users should rather use a recent channel instead of the MSRV.
+
 When compiling tests for the first time on a machine using the MSRV 1.69.0, an error might occur due to some dependencies of `near-workspaces` requiring a higher version of Rust. You can execute [./script/fix-dependencies.sh](./scripts/fix_dependencies.sh) to install a compatible version of these dependencies. The comments in that script provide additional information.
 
 

--- a/near-plugins-derive/src/access_control_role.rs
+++ b/near-plugins-derive/src/access_control_role.rs
@@ -68,7 +68,7 @@ pub fn derive_access_control_role(input: TokenStream) -> TokenStream {
 
     let variant_idents = variants.into_iter().map(|v| v.ident).collect::<Vec<_>>();
     assert!(
-        variant_idents.len() <= usize::try_from(MAX_ROLE_VARIANTS).unwrap(),
+        variant_idents.len() <= usize::from(MAX_ROLE_VARIANTS),
         "The number of enum variants should not exceed MAX_ROLE_VARIANTS",
     );
     let variant_idxs: Vec<_> =

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,3 @@
 [toolchain]
-channel = "1.69.0"
 components = ["clippy", "rustfmt"]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
I think this repo should not set a `channel` for [these reasons](https://github.com/aurora-is-near/near-plugins/pull/131/commits/d3b3ddfd4e18bb1aa055aa1ba61fe39791f2c550). Since by now users can be expected to have a default Rust toolchain >= 1.70 installed, it would also help to avoid issues like #130.

### Communication related to the MSRV

- The README now encourages developers to locally set `channel = <MSRV>`
- #132 points users that have to work with 1.69 to required fixes.

### Additional changes

Make CI install the toolchain to be used in tests right away by setting `toolchain: <MSRV>` in `test.yml`.