### PR TITLE
fix: update release-plz and skip publish verification for wasm32

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -24,18 +24,13 @@ jobs:
           fetch-depth: 0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-      - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@main
-      - name: Install release-plz
-        run: cargo-binstall release-plz --no-confirm
       - name: Run release-plz
-        run: release-plz release --git-token "$GITHUB_TOKEN" -o json
+        uses: release-plz/action@v0.5
+        with:
+          command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          CARGO_BUILD_TARGET: wasm32-unknown-unknown
 
   # Create a PR with the new versions and changelog, preparing the next release.
   release-plz-pr:
@@ -54,15 +49,10 @@ jobs:
           fetch-depth: 0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-      - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@main
-      - name: Install release-plz
-        run: cargo-binstall release-plz --no-confirm
       - name: Run release-plz
-        run: release-plz release-pr --git-token "$GITHUB_TOKEN" --repo-url "https://github.com/$GITHUB_REPOSITORY" -o json
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          CARGO_BUILD_TARGET: wasm32-unknown-unknown

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -24,20 +24,18 @@ jobs:
           fetch-depth: 0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-      # Set build target via .cargo/config.toml instead of CARGO_BUILD_TARGET env var.
-      # cargo-binstall reads CARGO_BUILD_TARGET and would try to install a wasm32 binary,
-      # but it ignores .cargo/config.toml.
-      - name: Set cargo build target
-        run: |
-          mkdir -p .cargo
-          echo -e '[build]\ntarget = "wasm32-unknown-unknown"' > .cargo/config.toml
-      - name: Run release-plz
-        uses: release-plz/action@v0.5
         with:
-          command: release
+          targets: wasm32-unknown-unknown
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@main
+      - name: Install release-plz
+        run: cargo-binstall release-plz --no-confirm
+      - name: Run release-plz
+        run: release-plz release --git-token "$GITHUB_TOKEN" -o json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_BUILD_TARGET: wasm32-unknown-unknown
 
   # Create a PR with the new versions and changelog, preparing the next release.
   release-plz-pr:
@@ -56,14 +54,15 @@ jobs:
           fetch-depth: 0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-      - name: Set cargo build target
-        run: |
-          mkdir -p .cargo
-          echo -e '[build]\ntarget = "wasm32-unknown-unknown"' > .cargo/config.toml
-      - name: Run release-plz
-        uses: release-plz/action@v0.5
         with:
-          command: release-pr
+          targets: wasm32-unknown-unknown
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@main
+      - name: Install release-plz
+        run: cargo-binstall release-plz --no-confirm
+      - name: Run release-plz
+        run: release-plz release-pr --git-token "$GITHUB_TOKEN" --repo-url "https://github.com/$GITHUB_REPOSITORY" -o json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_BUILD_TARGET: wasm32-unknown-unknown

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -24,6 +24,13 @@ jobs:
           fetch-depth: 0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      # Set build target via .cargo/config.toml instead of CARGO_BUILD_TARGET env var.
+      # cargo-binstall reads CARGO_BUILD_TARGET and would try to install a wasm32 binary,
+      # but it ignores .cargo/config.toml.
+      - name: Set cargo build target
+        run: |
+          mkdir -p .cargo
+          echo -e '[build]\ntarget = "wasm32-unknown-unknown"' > .cargo/config.toml
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:
@@ -31,7 +38,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          CARGO_BUILD_TARGET: wasm32-unknown-unknown
 
   # Create a PR with the new versions and changelog, preparing the next release.
   release-plz-pr:
@@ -50,6 +56,10 @@ jobs:
           fetch-depth: 0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - name: Set cargo build target
+        run: |
+          mkdir -p .cargo
+          echo -e '[build]\ntarget = "wasm32-unknown-unknown"' > .cargo/config.toml
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:
@@ -57,4 +67,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          CARGO_BUILD_TARGET: wasm32-unknown-unknown

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,2 @@
+[workspace]
+publish_no_verify = true


### PR DESCRIPTION
## Summary
- Add `publish_no_verify = true` to skip the cargo publish verification build that requires wasm32
- Remove `CARGO_BUILD_TARGET` from the workflow so cargo-binstall can install release-plz natively

Same approach as near/near-sdk-rs#1532.