### PR TITLE
fix: remove .cargo/config.toml step that breaks release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -24,13 +24,6 @@ jobs:
           fetch-depth: 0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-      # Set build target via .cargo/config.toml instead of CARGO_BUILD_TARGET env var.
-      # cargo-binstall reads CARGO_BUILD_TARGET and would try to install a wasm32 binary,
-      # but it ignores .cargo/config.toml.
-      - name: Set cargo build target
-        run: |
-          mkdir -p .cargo
-          echo -e '[build]\ntarget = "wasm32-unknown-unknown"' > .cargo/config.toml
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:
@@ -56,10 +49,6 @@ jobs:
           fetch-depth: 0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-      - name: Set cargo build target
-        run: |
-          mkdir -p .cargo
-          echo -e '[build]\ntarget = "wasm32-unknown-unknown"' > .cargo/config.toml
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:


### PR DESCRIPTION
The "Set cargo build target" steps from #191 create .cargo/config.toml at runtime, which release-plz detects as uncommitted changes and refuses to run. No longer needed since publish_no_verify (#192) skips the verification build.